### PR TITLE
Remove dependency to quickitem in renderer as this may lead to issued…

### DIFF
--- a/src/RiveQtQuickItem/renderer/riveqtfactory.cpp
+++ b/src/RiveQtQuickItem/renderer/riveqtfactory.cpp
@@ -19,7 +19,7 @@
 #endif
 
 RiveQSGRenderNode *RiveQtFactory::renderNode(QQuickWindow *window, std::weak_ptr<rive::ArtboardInstance> artboardInstance,
-                                             RiveQtQuickItem *item)
+                                             const QRectF &geometry)
 {
     switch (window->rendererInterface()->graphicsApi()) {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
@@ -27,18 +27,18 @@ RiveQSGRenderNode *RiveQtFactory::renderNode(QQuickWindow *window, std::weak_ptr
     case QSGRendererInterface::GraphicsApi::MetalRhi:
     case QSGRendererInterface::GraphicsApi::VulkanRhi:
     case QSGRendererInterface::GraphicsApi::Direct3D11Rhi: {
-        auto node = new RiveQSGRHIRenderNode(artboardInstance, item);
+        auto node = new RiveQSGRHIRenderNode(window, artboardInstance, geometry);
         node->setFillMode(m_renderSettings.fillMode);
         return node;
     }
 #else
     case QSGRendererInterface::GraphicsApi::OpenGL:
-        return new RiveQSGOpenGLRenderNode(artboardInstance, item);
+        return new RiveQSGOpenGLRenderNode(window, artboardInstance, geometry);
         break;
 #endif
     case QSGRendererInterface::GraphicsApi::Software:
     default:
-        return new RiveQSGSoftwareRenderNode(window, artboardInstance, item);
+        return new RiveQSGSoftwareRenderNode(window, artboardInstance, geometry);
     }
 }
 

--- a/src/RiveQtQuickItem/renderer/riveqtfactory.h
+++ b/src/RiveQtQuickItem/renderer/riveqtfactory.h
@@ -38,7 +38,7 @@ public:
 
     void setRenderSettings(const RiveRenderSettings &renderSettings) { m_renderSettings = renderSettings; }
 
-    RiveQSGRenderNode *renderNode(QQuickWindow *window, std::weak_ptr<rive::ArtboardInstance> artboardInstance, RiveQtQuickItem *item);
+    RiveQSGRenderNode *renderNode(QQuickWindow *window, std::weak_ptr<rive::ArtboardInstance> artboardInstance, const QRectF &geometry);
 
     rive::rcp<rive::RenderBuffer> makeBufferU16(rive::Span<const uint16_t> data) override;
     rive::rcp<rive::RenderBuffer> makeBufferU32(rive::Span<const uint32_t> data) override;

--- a/src/RiveQtQuickItem/renderer/riveqtrhirenderer.cpp
+++ b/src/RiveQtQuickItem/renderer/riveqtrhirenderer.cpp
@@ -18,9 +18,9 @@
 #include "renderer/riveqtrhirenderer.h"
 #include "rhi/texturetargetnode.h"
 
-RiveQtRhiRenderer::RiveQtRhiRenderer(QQuickItem *item)
+RiveQtRhiRenderer::RiveQtRhiRenderer(QQuickWindow *window)
     : rive::Renderer()
-    , m_item(item)
+    , m_window(window)
 {
     m_rhiRenderStack.push_back(RhiRenderState());
 }
@@ -203,7 +203,7 @@ TextureTargetNode *RiveQtRhiRenderer::getRiveDrawTargetNode()
     }
 
     if (!pathNode) {
-        pathNode = new TextureTargetNode(m_item, m_displayBuffer, m_viewportRect, &m_combinedMatrix, &m_projectionMatrix);
+        pathNode = new TextureTargetNode(m_window, m_displayBuffer, m_viewportRect, &m_combinedMatrix, &m_projectionMatrix);
         pathNode->take();
         m_renderNodes.append(pathNode);
     }

--- a/src/RiveQtQuickItem/renderer/riveqtrhirenderer.h
+++ b/src/RiveQtQuickItem/renderer/riveqtrhirenderer.h
@@ -35,7 +35,7 @@ struct RhiRenderState
 class RiveQtRhiRenderer : public rive::Renderer
 {
 public:
-    RiveQtRhiRenderer(QQuickItem *item);
+    RiveQtRhiRenderer(QQuickWindow *window);
     virtual ~RiveQtRhiRenderer();
     void setRiveRect(const QRectF &bounds) { m_riveRect = bounds; }
 
@@ -62,11 +62,10 @@ private:
     const QMatrix4x4 &transformMatrix() const;
     float currentOpacity();
 
-    QQuickItem *m_item;
-
     QVector<RhiRenderState> m_rhiRenderStack;
     QVector<TextureTargetNode *> m_renderNodes;
 
+    QQuickWindow *m_window;
     QRhiTexture *m_displayBuffer;
 
     QMatrix4x4 m_projectionMatrix;

--- a/src/RiveQtQuickItem/rhi/texturetargetnode.cpp
+++ b/src/RiveQtQuickItem/rhi/texturetargetnode.cpp
@@ -13,14 +13,12 @@
 #include <private/qrhi_p.h>
 #include <private/qsgrendernode_p.h>
 
-TextureTargetNode::TextureTargetNode(QQuickItem *item, QRhiTexture *displayBuffer, const QRectF &viewPortRect,
+TextureTargetNode::TextureTargetNode(QQuickWindow *window, QRhiTexture *displayBuffer, const QRectF &viewPortRect,
                                      const QMatrix4x4 *combinedMatrix, const QMatrix4x4 *projectionMatrix)
-    : m_item(item)
-    , m_combinedMatrix(combinedMatrix)
+    : m_combinedMatrix(combinedMatrix)
     , m_projectionMatrix(projectionMatrix)
+    , m_window(window)
 {
-    m_window = item->window();
-
     QFile file;
     file.setFileName(":/shaders/qt6/drawRiveTextureNode.vert.qsb");
     file.open(QFile::ReadOnly);

--- a/src/RiveQtQuickItem/rhi/texturetargetnode.h
+++ b/src/RiveQtQuickItem/rhi/texturetargetnode.h
@@ -34,7 +34,7 @@ class QQuickItem;
 class TextureTargetNode
 {
 public:
-    TextureTargetNode(QQuickItem *item, QRhiTexture *displayBuffer, const QRectF &viewPortRect, const QMatrix4x4 *combinedMatrix,
+    TextureTargetNode(QQuickWindow *window, QRhiTexture *displayBuffer, const QRectF &viewPortRect, const QMatrix4x4 *combinedMatrix,
                       const QMatrix4x4 *projectMatrix);
     virtual ~TextureTargetNode();
 
@@ -125,7 +125,6 @@ private:
     QRhiResourceUpdateBatch *m_blendResourceUpdates { nullptr };
 
     QQuickWindow *m_window { nullptr };
-    QQuickItem *m_item { nullptr };
 
     // Material Related // Shader Related data
     QColor m_color;

--- a/src/RiveQtQuickItem/riveqsgopenglrendernode.h
+++ b/src/RiveQtQuickItem/riveqsgopenglrendernode.h
@@ -21,7 +21,7 @@ class RiveQtQuickItem;
 class RiveQSGOpenGLRenderNode : public RiveQSGRenderNode, public QOpenGLFunctions
 {
 public:
-    RiveQSGOpenGLRenderNode(std::weak_ptr<rive::ArtboardInstance> artboardInstance, RiveQtQuickItem *item);
+    RiveQSGOpenGLRenderNode(QQuickWindow *window, std::weak_ptr<rive::ArtboardInstance> artboardInstance, const QRectF &geometry);
 
     void render(const RenderState *state) override;
 

--- a/src/RiveQtQuickItem/riveqsgrendernode.cpp
+++ b/src/RiveQtQuickItem/riveqsgrendernode.cpp
@@ -8,18 +8,19 @@
 
 QRectF RiveQSGRenderNode::rect() const
 {
-    return m_item->boundingRect();
+    return m_rect;
 }
 
-RiveQSGRenderNode::RiveQSGRenderNode(std::weak_ptr<rive::ArtboardInstance> artboardInstance, RiveQtQuickItem *item)
-    : RiveQSGBaseNode(artboardInstance, item)
+RiveQSGRenderNode::RiveQSGRenderNode(QQuickWindow *window, std::weak_ptr<rive::ArtboardInstance> artboardInstance, const QRectF &geometry)
+    : RiveQSGBaseNode(window, artboardInstance, geometry)
 {
 }
 
-RiveQSGBaseNode::RiveQSGBaseNode(std::weak_ptr<rive::ArtboardInstance> artboardInstance, RiveQtQuickItem *item)
+RiveQSGBaseNode::RiveQSGBaseNode(QQuickWindow *window, std::weak_ptr<rive::ArtboardInstance> artboardInstance, const QRectF &geometry)
     : m_artboardInstance(artboardInstance)
-    , m_item(item)
+    , m_window(window)
 {
+    Q_ASSERT(m_window);
 }
 
 void RiveQSGBaseNode::setRect(const QRectF &bounds)

--- a/src/RiveQtQuickItem/riveqsgrendernode.h
+++ b/src/RiveQtQuickItem/riveqsgrendernode.h
@@ -13,14 +13,11 @@
 
 #include <rive/artboard.hpp>
 
-class RiveQtQuickItem;
-
 class RiveQSGBaseNode
 {
 public:
-    RiveQSGBaseNode(std::weak_ptr<rive::ArtboardInstance> artboardInstance, RiveQtQuickItem *item);
+    RiveQSGBaseNode(QQuickWindow *window, std::weak_ptr<rive::ArtboardInstance> artboardInstance, const QRectF &geometry);
 
-    virtual void detach() { m_item = nullptr; }
     virtual void renderOffscreen() { }
     virtual void setRect(const QRectF &bounds);
     virtual QPointF topLeft() const;
@@ -33,10 +30,10 @@ public:
 
 protected:
     std::weak_ptr<rive::ArtboardInstance> m_artboardInstance;
-    RiveQtQuickItem *m_item { nullptr };
     QRectF m_rect;
     QPointF m_topLeftRivePosition { 0.f, 0.f };
     QSizeF m_riveSize { 0.f, 0.f };
+    QQuickWindow *m_window;
 
     float m_scaleFactorX { 1.0f };
     float m_scaleFactorY { 1.0f };
@@ -45,7 +42,7 @@ protected:
 class RiveQSGRenderNode : public QSGRenderNode, public RiveQSGBaseNode
 {
 public:
-    RiveQSGRenderNode(std::weak_ptr<rive::ArtboardInstance> artboardInstance, RiveQtQuickItem *item);
+    RiveQSGRenderNode(QQuickWindow *window, std::weak_ptr<rive::ArtboardInstance> artboardInstance, const QRectF &geometry);
 
     StateFlags changedStates() const override { return QSGRenderNode::BlendState; }
     RenderingFlags flags() const override { return QSGRenderNode::BoundedRectRendering | QSGRenderNode::DepthAwareRendering; }

--- a/src/RiveQtQuickItem/riveqsgrhirendernode.h
+++ b/src/RiveQtQuickItem/riveqsgrhirendernode.h
@@ -28,7 +28,7 @@ class RiveQtRhiRenderer;
 class RiveQSGRHIRenderNode : public RiveQSGRenderNode
 {
 public:
-    RiveQSGRHIRenderNode(std::weak_ptr<rive::ArtboardInstance> artboardInstance, RiveQtQuickItem *item);
+    RiveQSGRHIRenderNode(QQuickWindow *window, std::weak_ptr<rive::ArtboardInstance> artboardInstance, const QRectF &geometry);
     virtual ~RiveQSGRHIRenderNode();
 
     void setRect(const QRectF &bounds) override;
@@ -46,8 +46,6 @@ public:
     QSGRenderNode::StateFlags changedStates() const override;
 
 protected:
-    QQuickWindow *m_window { nullptr };
-
     QRhiBuffer *m_vertexBuffer { nullptr };
     QRhiBuffer *m_texCoordBuffer { nullptr };
     QRhiBuffer *m_uniformBuffer { nullptr };

--- a/src/RiveQtQuickItem/riveqsgsoftwarerendernode.cpp
+++ b/src/RiveQtQuickItem/riveqsgsoftwarerendernode.cpp
@@ -10,18 +10,14 @@
 #include "riveqsgsoftwarerendernode.h"
 
 RiveQSGSoftwareRenderNode::RiveQSGSoftwareRenderNode(QQuickWindow *window, std::weak_ptr<rive::ArtboardInstance> artboardInstance,
-                                                     RiveQtQuickItem *item)
-    : RiveQSGRenderNode(artboardInstance, item)
-    , m_window(window)
+                                                     const QRectF &geometry)
+    : RiveQSGRenderNode(window, artboardInstance, geometry)
 {
 }
 
 QRectF RiveQSGSoftwareRenderNode::rect() const
 {
-    if (!m_item) {
-        return QRectF(0, 0, 0, 0);
-    }
-    return QRectF(0, 0, m_item->width(), m_item->height());
+    return QRectF(0, 0, m_rect.width(), m_rect.height());
 }
 
 void RiveQSGSoftwareRenderNode::render(const RenderState *state)
@@ -41,24 +37,23 @@ void RiveQSGSoftwareRenderNode::renderSoftware(const RenderState *state)
         return;
     }
 
-    if (!m_item) {
+    if (!m_window) {
         return;
     }
 
     auto *renderInterface = m_window->rendererInterface();
     if (renderInterface->graphicsApi() != QSGRendererInterface::GraphicsApi::Software) {
-
         return;
     }
 
     auto artboardInstance = m_artboardInstance.lock();
 
-    QPointF globalPos = m_item->mapToItem(nullptr, QPointF(0, 0));
-    auto x = globalPos.x();
-    auto y = globalPos.y();
+    const QRect &boundingRect = state->clipRegion()->boundingRect();
+    auto x = boundingRect.x();
+    auto y = boundingRect.y();
 
-    auto aspectX = m_item->width() / (artboardInstance->width());
-    auto aspectY = m_item->height() / (artboardInstance->height());
+    auto aspectX = boundingRect.width() / (artboardInstance->width());
+    auto aspectY = boundingRect.height() / (artboardInstance->height());
 
     // Calculate the uniform scale factor to preserve the aspect ratio
     auto scaleFactor = qMin(aspectX, aspectY);
@@ -68,8 +63,8 @@ void RiveQSGSoftwareRenderNode::renderSoftware(const RenderState *state)
     auto newHeight = artboardInstance->height() * scaleFactor;
 
     // Calculate the offsets needed to center the item within its bounding rectangle
-    auto offsetX = (m_item->width() - newWidth) / 2.0;
-    auto offsetY = (m_item->height() - newHeight) / 2.0;
+    auto offsetX = (boundingRect.width() - newWidth) / 2.0;
+    auto offsetY = (boundingRect.height() - newHeight) / 2.0;
 
     // TODO this only works for PreserverAspectFit
     m_scaleFactorX = scaleFactor;
@@ -98,14 +93,14 @@ void RiveQSGSoftwareRenderNode::renderSoftware(const RenderState *state)
         modelViewTransform.scale(scaleFactor, scaleFactor);
 
         painter->setTransform(modelViewTransform, false);
+
+        m_renderer.setPainter(painter);
+
+        painter->save();
+        {
+            artboardInstance->draw(&m_renderer);
+        }
+        painter->restore();
     }
-
-    m_renderer.setPainter(painter);
-
-    painter->save();
-    {
-        artboardInstance->draw(&m_renderer);
-    }
-
     painter->restore();
 }

--- a/src/RiveQtQuickItem/riveqsgsoftwarerendernode.h
+++ b/src/RiveQtQuickItem/riveqsgsoftwarerendernode.h
@@ -23,7 +23,7 @@ class QQuickWindow;
 class RiveQSGSoftwareRenderNode : public RiveQSGRenderNode
 {
 public:
-    RiveQSGSoftwareRenderNode(QQuickWindow *window, std::weak_ptr<rive::ArtboardInstance> artboardInstance, RiveQtQuickItem *item);
+    RiveQSGSoftwareRenderNode(QQuickWindow *window, std::weak_ptr<rive::ArtboardInstance> artboardInstance, const QRectF &geometry);
 
     QRectF rect() const override;
 
@@ -36,7 +36,6 @@ private:
     void renderSoftware(const RenderState *state);
 
     RiveQtPainterRenderer m_renderer;
-    QQuickWindow *m_window { nullptr };
 
     QPainter m_fallbackPainter;
     QPixmap m_fallbackPixmap;

--- a/src/RiveQtQuickItem/riveqtpath.h
+++ b/src/RiveQtQuickItem/riveqtpath.h
@@ -48,7 +48,6 @@ private:
                         qreal t);
 
     QPainterPath m_path;
-    std::vector<SubPath> m_subPaths;
     QVector<QVector<QVector2D>> m_pathSegmentsData;
     QVector<QVector<QVector2D>> m_pathSegmentsOutlineData;
     QVector<QVector<QVector2D>> m_pathOutlineData;
@@ -59,22 +58,9 @@ private:
 
     unsigned m_segmentCount { 10 };
     void addMiterJoin(QVector<QVector2D> &lineDataSegment, const QVector2D &p1, const QVector2D &p2, const QVector2D &offset);
-    void addRoundJoin(QVector<QVector2D> &lineDataSegment, const float &lineWidth, const QVector2D &p1, const QVector2D &p2, const QVector2D &offset,
-                      int numSegments);
+    void addRoundJoin(QVector<QVector2D> &lineDataSegment, const float &lineWidth, const QVector2D &p1, const QVector2D &p2,
+                      const QVector2D &offset, int numSegments);
     void addBevelJoin(QVector<QVector2D> &lineDataSegment, const QVector2D &p1, const QVector2D &p2, const QVector2D &offset);
     void addCap(QVector<QVector2D> &lineDataSegment, const float &lineWidth, const Qt::PenCapStyle &capStyle, const QVector2D &p,
                 const QVector2D &offset, const QVector2D &normal, const bool &isStart);
-};
-
-class SubPath
-{
-public:
-    SubPath(RiveQtPath *path, const QMatrix4x4 &transform);
-
-    RiveQtPath *path() const;
-    QMatrix4x4 transform() const;
-
-private:
-    RiveQtPath *m_Path;
-    QMatrix4x4 m_Transform;
 };

--- a/src/RiveQtQuickItem/riveqtquickitem.h
+++ b/src/RiveQtQuickItem/riveqtquickitem.h
@@ -168,7 +168,6 @@ private:
     QRectF artboardRect();
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    friend RiveQSGRHIRenderNode;
     void renderOffscreen();
 #endif
 

--- a/src/RiveQtQuickItem/shaders/qt6/blendRiveTextureNode.frag
+++ b/src/RiveQtQuickItem/shaders/qt6/blendRiveTextureNode.frag
@@ -333,6 +333,6 @@ void main()
    vec4 destColor = texture(u_texture_dest, texCoord);
    vec4 finalColor = blend(srcColor, destColor, blendMode);
 
-   finalColor.a = 1.0f;
+   //finalColor.a = 1.0f;
    fragColor = finalColor;
 }

--- a/src/RiveQtQuickItem/shaders/qt6/finalDraw.vert
+++ b/src/RiveQtQuickItem/shaders/qt6/finalDraw.vert
@@ -25,5 +25,5 @@ void main()
     } else {
         texCoord = vec2(aTexCoord.x, 1.0 - aTexCoord.y); // Pass the texture coordinates to the fragment shader
     }
-    gl_Position = qt_Matrix * vec4(vertex, 0.0, 1.0);
+    gl_Position = qt_Matrix *  vec4(vertex, 0.0, 1.0);
 }


### PR DESCRIPTION
… during dynamic item destruction

Make use of model-matrix to allow render position manipulation by standard qt animation framework