### PR TITLE
Avoid unloading Loop

### DIFF
--- a/src/RiveQtQuickItem/riveqtquickitem.cpp
+++ b/src/RiveQtQuickItem/riveqtquickitem.cpp
@@ -142,6 +142,9 @@ void RiveQtQuickItem::updateInternalArtboard()
 
 QSGNode *RiveQtQuickItem::updatePaintNode(QSGNode *oldNode, UpdatePaintNodeData *)
 {
+    if (m_loadingGuard) {
+        return oldNode;
+    }
     static QElapsedTimer et;
     QQuickWindow *currentWindow = window();
 
@@ -154,6 +157,7 @@ QSGNode *RiveQtQuickItem::updatePaintNode(QSGNode *oldNode, UpdatePaintNodeData 
     // unload the file from the render thread to make sure its not accessed at time of unloading
     if (m_loadingStatus == Unloading && m_renderNode) {
         qCDebug(rqqpItem) << "Unloading";
+        m_loadingGuard = true;
         m_stateMachineInterface->disconnect();
         m_stateMachineInterface->deleteLater();
         m_stateMachineInterface = nullptr;
@@ -481,6 +485,7 @@ void RiveQtQuickItem::loadRiveFile(const QString &source)
 
     qCDebug(rqqpItem) << "Successfully imported Rive file.";
     m_loadingStatus = Loaded;
+    m_loadingGuard = false;
     emit loadingStatusChanged();
 }
 

--- a/src/RiveQtQuickItem/riveqtquickitem.h
+++ b/src/RiveQtQuickItem/riveqtquickitem.h
@@ -522,4 +522,6 @@ private:
 
     RiveQSGRenderNode *m_renderNode { nullptr };
     void updateStateMachineValues();
+
+    bool m_loadingGuard {false};
 };


### PR DESCRIPTION
At times, the application crashes when the user updates the Rive file due to excessive calls to updatePaintNode.

The crash occurs within the code responsible for updating the state machine:

The root cause appears to be multiple invocations of updatePaintNode() during the unloading phase, leading to multiple emits of the loadFileAfterUnloading() signal.

The function loadFileAfterUnloading() triggers the state machine update code. During the unloading phase, the artboard instance retains dangling pointers to the state machines, thereby causing the crash.