### PR TITLE
Remove texture copy

### DIFF
--- a/src/RiveQtQuickItem/rhi/texturetargetnode.h
+++ b/src/RiveQtQuickItem/rhi/texturetargetnode.h
@@ -119,7 +119,6 @@ private:
     QRhiTexture *m_internalDisplayBufferTexture { nullptr };
     QRhiTexture *m_qImageTexture { nullptr };
     QRhiTexture *m_blendSrc { nullptr };
-    QRhiTexture *m_blendDest { nullptr };
 
     QRhiResourceUpdateBatch *m_resourceUpdates { nullptr };
     QRhiResourceUpdateBatch *m_blendResourceUpdates { nullptr };


### PR DESCRIPTION
The second texture copy is not necessary, because it is only used for sampling (READ operation) in this pass. The display buffer is used for both - for sampling and as a render target.