### PR TITLE
refactor rhi drawing.

### DIFF
--- a/src/RiveQtQuickItem/CMakeLists.txt
+++ b/src/RiveQtQuickItem/CMakeLists.txt
@@ -108,6 +108,7 @@ endif()
 
 include_directories(${Qt${QT_VERSION_MAJOR}Gui_PRIVATE_INCLUDE_DIRS})
 
+# Add before BATCHABLE in case we want to use textureSize in shader: GLSL "300es,330"
 if (${QT_VERSION_MAJOR} EQUAL 6)
     find_package(Qt6 COMPONENTS ShaderTools)
     qt6_add_shaders(${PROJECT_NAME} "graph-shaders"

--- a/src/RiveQtQuickItem/renderer/riveqtrhirenderer.cpp
+++ b/src/RiveQtQuickItem/renderer/riveqtrhirenderer.cpp
@@ -18,9 +18,10 @@
 #include "renderer/riveqtrhirenderer.h"
 #include "rhi/texturetargetnode.h"
 
-RiveQtRhiRenderer::RiveQtRhiRenderer(QQuickWindow *window)
+RiveQtRhiRenderer::RiveQtRhiRenderer(QQuickWindow *window, RiveQSGRHIRenderNode *node)
     : rive::Renderer()
     , m_window(window)
+    , m_node(node)
 {
     m_rhiRenderStack.push_back(RhiRenderState());
 }
@@ -203,7 +204,7 @@ TextureTargetNode *RiveQtRhiRenderer::getRiveDrawTargetNode()
     }
 
     if (!pathNode) {
-        pathNode = new TextureTargetNode(m_window, m_displayBuffer, m_viewportRect, &m_combinedMatrix, &m_projectionMatrix);
+        pathNode = new TextureTargetNode(m_window, m_node, m_viewportRect, &m_combinedMatrix, &m_projectionMatrix);
         pathNode->take();
         m_renderNodes.append(pathNode);
     }
@@ -217,7 +218,7 @@ void RiveQtRhiRenderer::setProjectionMatrix(const QMatrix4x4 *projectionMatrix, 
     m_combinedMatrix = *combinedMatrix;
 }
 
-void RiveQtRhiRenderer::updateViewPort(const QRectF &viewportRect, QRhiTexture *displayBuffer)
+void RiveQtRhiRenderer::updateViewPort(const QRectF &viewportRect)
 {
     while (!m_renderNodes.empty()) {
         auto *textureTargetNode = m_renderNodes.last();
@@ -226,7 +227,6 @@ void RiveQtRhiRenderer::updateViewPort(const QRectF &viewportRect, QRhiTexture *
     }
 
     m_viewportRect = viewportRect;
-    m_displayBuffer = displayBuffer;
 }
 
 void RiveQtRhiRenderer::recycleRiveNodes()

--- a/src/RiveQtQuickItem/renderer/riveqtrhirenderer.h
+++ b/src/RiveQtQuickItem/renderer/riveqtrhirenderer.h
@@ -22,6 +22,7 @@
 class RhiSubPath;
 class QSGRenderNode;
 class TextureTargetNode;
+class RiveQSGRHIRenderNode;
 
 struct RhiRenderState
 {
@@ -35,7 +36,7 @@ struct RhiRenderState
 class RiveQtRhiRenderer : public rive::Renderer
 {
 public:
-    RiveQtRhiRenderer(QQuickWindow *window);
+    RiveQtRhiRenderer(QQuickWindow *window, RiveQSGRHIRenderNode *node);
     virtual ~RiveQtRhiRenderer();
     void setRiveRect(const QRectF &bounds) { m_riveRect = bounds; }
 
@@ -51,7 +52,7 @@ public:
 
     void setProjectionMatrix(const QMatrix4x4 *projectionMatrix, const QMatrix4x4 *combinedMatrix);
     void updateArtboardSize(const QSize &artboardSize) { m_artboardSize = artboardSize; }
-    void updateViewPort(const QRectF &viewportRect, QRhiTexture *displayBuffer);
+    void updateViewPort(const QRectF &viewportRect);
     void recycleRiveNodes();
 
     void render(QRhiCommandBuffer *cb);
@@ -66,7 +67,6 @@ private:
     QVector<TextureTargetNode *> m_renderNodes;
 
     QQuickWindow *m_window;
-    QRhiTexture *m_displayBuffer;
 
     QMatrix4x4 m_projectionMatrix;
     QMatrix4x4 m_combinedMatrix;
@@ -74,4 +74,6 @@ private:
     QSize m_artboardSize;
     QRectF m_viewportRect;
     QRectF m_riveRect;
+
+    RiveQSGRHIRenderNode *m_node;
 };

--- a/src/RiveQtQuickItem/rhi/postprocessingsmaa.cpp
+++ b/src/RiveQtQuickItem/rhi/postprocessingsmaa.cpp
@@ -15,20 +15,13 @@
 #include "textures/SearchTex.h"
 
 // quad for our onscreen texture
-static float vertexData[] =
-{ // Y up, CCW
-  -1.0f,   1.0f,   0.0f, 0.0f,
-  -1.0f,  -1.0f,   0.0f, 1.0f,
-  1.0f,   -1.0f,   1.0f, 1.0f,
-  1.0f,   1.0f,    1.0f, 0.0f
+static float vertexData[] = { // Y up, CCW
+    -1.0f, 1.0f, 0.0f, 0.0f, -1.0f, -1.0f, 0.0f, 1.0f, 1.0f, -1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 0.0f
 };
 
-static quint16 indexData[] =
-{
-    0, 1, 2, 0, 2, 3
-};
+static quint16 indexData[] = { 0, 1, 2, 0, 2, 3 };
 
-// resolution (2 * 4) + flip (4) 
+// resolution (2 * 4) + flip (4)
 const int UBUFSIZE = 12;
 
 QShader getShader(const QString &name)
@@ -57,10 +50,10 @@ PostprocessingSMAA::PostprocessingSMAA()
     QRhiShaderStage blendFragment = loadShader(QRhiShaderStage::Fragment, ":/shaders/qt6/smaa-blend.frag.qsb");
 
     m_shaders.blendPass = { blendVertex, blendFragment };
-
 }
 
-PostprocessingSMAA::~PostprocessingSMAA() {
+PostprocessingSMAA::~PostprocessingSMAA()
+{
     // clear initializePostprocessingPipeline part
     cleanup();
 
@@ -69,7 +62,6 @@ PostprocessingSMAA::~PostprocessingSMAA() {
     m_shaders.weightsPass.clear();
     m_shaders.blendPass.clear();
 }
-
 
 QRhiShaderStage PostprocessingSMAA::loadShader(QRhiShaderStage::Type type, const QString &filename) const
 {
@@ -93,10 +85,10 @@ QByteArray PostprocessingSMAA::loadAreaTextureAsRGBA8Array()
 
     // RHI doesn't support R8G8 textures, so convert to RGBA8
     for (auto k = 0; k < textureSize; k++) {
-        data[4 * k + 0] = areaTexBytes[2 * k];      // r (data channel)
-        data[4 * k + 1] = areaTexBytes[2 * k + 1];  // g (data channel)
-        data[4 * k + 2] = empty;                    // b (empty)
-        data[4 * k + 3] = full;                     // a
+        data[4 * k + 0] = areaTexBytes[2 * k]; // r (data channel)
+        data[4 * k + 1] = areaTexBytes[2 * k + 1]; // g (data channel)
+        data[4 * k + 2] = empty; // b (empty)
+        data[4 * k + 3] = full; // a
     }
 
     return data;
@@ -108,12 +100,12 @@ QByteArray PostprocessingSMAA::loadSearchTextureAsR8Array()
     // one channel texture
     assert(textureSize == sizeof(searchTexBytes) / sizeof(searchTexBytes[0]));
 
-    return QByteArray(reinterpret_cast<const char*>(searchTexBytes), textureSize);
+    return QByteArray(reinterpret_cast<const char *>(searchTexBytes), textureSize);
 }
 
-//void PostprocessingSMAA::initializePostprocessingPipeline(QRhi* rhi, const QSizeF &size, std::weak_ptr<QRhiTexture> frameTexture)
-void PostprocessingSMAA::initializePostprocessingPipeline(QRhi *rhi, QRhiCommandBuffer* commandBuffer,
-        const QSize &size, QRhiTexture* frameTexture)
+// void PostprocessingSMAA::initializePostprocessingPipeline(QRhi* rhi, const QSizeF &size, std::weak_ptr<QRhiTexture> frameTexture)
+void PostprocessingSMAA::initializePostprocessingPipeline(QRhi *rhi, QRhiCommandBuffer *commandBuffer, const QSize &size,
+                                                          QRhiTexture *frameTexture)
 {
 
     // maybe cleanup (check in method)
@@ -139,8 +131,8 @@ void PostprocessingSMAA::initializePostprocessingPipeline(QRhi *rhi, QRhiCommand
     resourceUpdates->uploadStaticBuffer(m_common.quadVertexBuffer, 0, sizeof(vertexData), vertexData);
     resourceUpdates->uploadStaticBuffer(m_common.quadIndexBuffer, indexData);
 
-    m_frameSampler = rhi->newSampler(QRhiSampler::Linear, QRhiSampler::Linear, QRhiSampler::None,
-                                QRhiSampler::ClampToEdge, QRhiSampler::ClampToEdge);
+    m_frameSampler =
+        rhi->newSampler(QRhiSampler::Linear, QRhiSampler::Linear, QRhiSampler::None, QRhiSampler::ClampToEdge, QRhiSampler::ClampToEdge);
     m_releasePool << m_frameSampler;
     m_frameSampler->create();
 
@@ -149,17 +141,15 @@ void PostprocessingSMAA::initializePostprocessingPipeline(QRhi *rhi, QRhiCommand
     m_releasePool << m_edgesPass.edgesTexture;
     m_edgesPass.edgesTexture->create();
 
-    m_edgesPass.edgesSampler = rhi->newSampler(QRhiSampler::Linear, QRhiSampler::Linear, QRhiSampler::None,
-                                QRhiSampler::ClampToEdge, QRhiSampler::ClampToEdge);
+    m_edgesPass.edgesSampler =
+        rhi->newSampler(QRhiSampler::Linear, QRhiSampler::Linear, QRhiSampler::None, QRhiSampler::ClampToEdge, QRhiSampler::ClampToEdge);
     m_releasePool << m_edgesPass.edgesSampler;
     m_edgesPass.edgesSampler->create();
 
     QRhiVertexInputLayout quadInputLayout;
     quadInputLayout.setBindings({ { 4 * sizeof(float) } });
-    quadInputLayout.setAttributes({
-        { 0, 0, QRhiVertexInputAttribute::Float2, 0 },
-        { 0, 1, QRhiVertexInputAttribute::Float2, quint32(2 * sizeof(float)) }
-    });
+    quadInputLayout.setAttributes(
+        { { 0, 0, QRhiVertexInputAttribute::Float2, 0 }, { 0, 1, QRhiVertexInputAttribute::Float2, quint32(2 * sizeof(float)) } });
 
     // rendering pass for edges
     m_edgesPass.edgesTarget = rhi->newTextureRenderTarget({ m_edgesPass.edgesTexture });
@@ -171,12 +161,10 @@ void PostprocessingSMAA::initializePostprocessingPipeline(QRhi *rhi, QRhiCommand
 
     m_edgesPass.edgesResourceBindings = rhi->newShaderResourceBindings();
     m_releasePool << m_edgesPass.edgesResourceBindings;
-    m_edgesPass.edgesResourceBindings->setBindings({
-        QRhiShaderResourceBinding::uniformBuffer(
-            0, QRhiShaderResourceBinding::VertexStage | QRhiShaderResourceBinding::FragmentStage, m_common.quadUbuffer, 0, UBUFSIZE
-        ),
-        QRhiShaderResourceBinding::sampledTexture(1, QRhiShaderResourceBinding::FragmentStage, m_frameTexture, m_frameSampler)
-    });
+    m_edgesPass.edgesResourceBindings->setBindings(
+        { QRhiShaderResourceBinding::uniformBuffer(0, QRhiShaderResourceBinding::VertexStage | QRhiShaderResourceBinding::FragmentStage,
+                                                   m_common.quadUbuffer, 0, UBUFSIZE),
+          QRhiShaderResourceBinding::sampledTexture(1, QRhiShaderResourceBinding::FragmentStage, m_frameTexture, m_frameSampler) });
     m_edgesPass.edgesResourceBindings->create();
 
     m_edgesPass.edgesPipeline = rhi->newGraphicsPipeline();
@@ -193,8 +181,8 @@ void PostprocessingSMAA::initializePostprocessingPipeline(QRhi *rhi, QRhiCommand
     m_releasePool << m_weightsPass.weightsTexture;
     m_weightsPass.weightsTexture->create();
 
-    m_weightsPass.weightsSampler = rhi->newSampler(QRhiSampler::Linear, QRhiSampler::Linear, QRhiSampler::None,
-                                QRhiSampler::ClampToEdge, QRhiSampler::ClampToEdge);
+    m_weightsPass.weightsSampler =
+        rhi->newSampler(QRhiSampler::Linear, QRhiSampler::Linear, QRhiSampler::None, QRhiSampler::ClampToEdge, QRhiSampler::ClampToEdge);
     m_releasePool << m_weightsPass.weightsSampler;
     m_weightsPass.weightsSampler->create();
 
@@ -204,16 +192,15 @@ void PostprocessingSMAA::initializePostprocessingPipeline(QRhi *rhi, QRhiCommand
     m_releasePool << m_lookup.areaTexture;
     m_lookup.areaTexture->create();
 
-    m_lookup.areaSampler = rhi->newSampler(QRhiSampler::Linear, QRhiSampler::Linear, QRhiSampler::None,
-                                QRhiSampler::ClampToEdge, QRhiSampler::ClampToEdge);
+    m_lookup.areaSampler =
+        rhi->newSampler(QRhiSampler::Linear, QRhiSampler::Linear, QRhiSampler::None, QRhiSampler::ClampToEdge, QRhiSampler::ClampToEdge);
     m_releasePool << m_lookup.areaSampler;
     m_lookup.areaSampler->create();
 
     const auto areaTextureData = loadAreaTextureAsRGBA8Array();
 
-    // QImage areaDebug(reinterpret_cast<const unsigned char*>(areaTextureData.constData()), AREATEX_WIDTH, AREATEX_HEIGHT, QImage::Format_RGBA8888);
-    // areaDebug.save("AreaTest.png");
-    // qDebug() << "Area Texture size" << areaTextureData.size();
+    // QImage areaDebug(reinterpret_cast<const unsigned char*>(areaTextureData.constData()), AREATEX_WIDTH, AREATEX_HEIGHT,
+    // QImage::Format_RGBA8888); areaDebug.save("AreaTest.png"); qDebug() << "Area Texture size" << areaTextureData.size();
 
     QRhiTextureUploadDescription areaTextureDesc({ 0, 0, { areaTextureData.constData(), quint32(areaTextureData.size()) } });
     resourceUpdates->uploadTexture(m_lookup.areaTexture, areaTextureDesc);
@@ -222,16 +209,15 @@ void PostprocessingSMAA::initializePostprocessingPipeline(QRhi *rhi, QRhiCommand
     m_releasePool << m_lookup.searchTexture;
     m_lookup.searchTexture->create();
 
-    m_lookup.searchSampler = rhi->newSampler(QRhiSampler::Linear, QRhiSampler::Linear, QRhiSampler::None,
-                                QRhiSampler::ClampToEdge, QRhiSampler::ClampToEdge);
+    m_lookup.searchSampler =
+        rhi->newSampler(QRhiSampler::Linear, QRhiSampler::Linear, QRhiSampler::None, QRhiSampler::ClampToEdge, QRhiSampler::ClampToEdge);
     m_releasePool << m_lookup.searchSampler;
     m_lookup.searchSampler->create();
 
     const auto searchTextureData = loadSearchTextureAsR8Array();
 
-    // QImage searchDebug(reinterpret_cast<const unsigned char*>(searchTextureData.constData()), SEARCHTEX_WIDTH, SEARCHTEX_HEIGHT, QImage::Format_Grayscale8);
-    // searchDebug.save("SearchTest.png");
-    // qDebug() << "Search Texture size" << searchTextureData.size();
+    // QImage searchDebug(reinterpret_cast<const unsigned char*>(searchTextureData.constData()), SEARCHTEX_WIDTH, SEARCHTEX_HEIGHT,
+    // QImage::Format_Grayscale8); searchDebug.save("SearchTest.png"); qDebug() << "Search Texture size" << searchTextureData.size();
 
     QRhiTextureUploadDescription searchTextureDesc({ 0, 0, { searchTextureData.constData(), quint32(searchTextureData.size()) } });
     resourceUpdates->uploadTexture(m_lookup.searchTexture, searchTextureDesc);
@@ -246,14 +232,15 @@ void PostprocessingSMAA::initializePostprocessingPipeline(QRhi *rhi, QRhiCommand
 
     m_weightsPass.weightsResourceBindings = rhi->newShaderResourceBindings();
     m_releasePool << m_weightsPass.weightsResourceBindings;
-    m_weightsPass.weightsResourceBindings->setBindings({
-        QRhiShaderResourceBinding::uniformBuffer(
-            0, QRhiShaderResourceBinding::VertexStage | QRhiShaderResourceBinding::FragmentStage, m_common.quadUbuffer, 0, UBUFSIZE
-        ),
-        QRhiShaderResourceBinding::sampledTexture(1, QRhiShaderResourceBinding::FragmentStage, m_edgesPass.edgesTexture, m_edgesPass.edgesSampler),
-        QRhiShaderResourceBinding::sampledTexture(2, QRhiShaderResourceBinding::FragmentStage, m_lookup.areaTexture, m_lookup.areaSampler),
-        QRhiShaderResourceBinding::sampledTexture(3, QRhiShaderResourceBinding::FragmentStage, m_lookup.searchTexture, m_lookup.searchSampler)
-    });
+    m_weightsPass.weightsResourceBindings->setBindings(
+        { QRhiShaderResourceBinding::uniformBuffer(0, QRhiShaderResourceBinding::VertexStage | QRhiShaderResourceBinding::FragmentStage,
+                                                   m_common.quadUbuffer, 0, UBUFSIZE),
+          QRhiShaderResourceBinding::sampledTexture(1, QRhiShaderResourceBinding::FragmentStage, m_edgesPass.edgesTexture,
+                                                    m_edgesPass.edgesSampler),
+          QRhiShaderResourceBinding::sampledTexture(2, QRhiShaderResourceBinding::FragmentStage, m_lookup.areaTexture,
+                                                    m_lookup.areaSampler),
+          QRhiShaderResourceBinding::sampledTexture(3, QRhiShaderResourceBinding::FragmentStage, m_lookup.searchTexture,
+                                                    m_lookup.searchSampler) });
     m_weightsPass.weightsResourceBindings->create();
 
     m_weightsPass.weightsPipeline = rhi->newGraphicsPipeline();
@@ -279,13 +266,12 @@ void PostprocessingSMAA::initializePostprocessingPipeline(QRhi *rhi, QRhiCommand
     // rendering pass for blending
     m_blendPass.blendResourceBindings = rhi->newShaderResourceBindings();
     m_releasePool << m_blendPass.blendResourceBindings;
-    m_blendPass.blendResourceBindings->setBindings({
-        QRhiShaderResourceBinding::uniformBuffer(
-            0, QRhiShaderResourceBinding::VertexStage | QRhiShaderResourceBinding::FragmentStage, m_common.quadUbuffer, 0, UBUFSIZE
-        ),
-        QRhiShaderResourceBinding::sampledTexture(1, QRhiShaderResourceBinding::FragmentStage, m_frameTexture, m_frameSampler),
-        QRhiShaderResourceBinding::sampledTexture(2, QRhiShaderResourceBinding::FragmentStage, m_weightsPass.weightsTexture, m_weightsPass.weightsSampler)
-    });
+    m_blendPass.blendResourceBindings->setBindings(
+        { QRhiShaderResourceBinding::uniformBuffer(0, QRhiShaderResourceBinding::VertexStage | QRhiShaderResourceBinding::FragmentStage,
+                                                   m_common.quadUbuffer, 0, UBUFSIZE),
+          QRhiShaderResourceBinding::sampledTexture(1, QRhiShaderResourceBinding::FragmentStage, m_frameTexture, m_frameSampler),
+          QRhiShaderResourceBinding::sampledTexture(2, QRhiShaderResourceBinding::FragmentStage, m_weightsPass.weightsTexture,
+                                                    m_weightsPass.weightsSampler) });
     m_blendPass.blendResourceBindings->create();
 
     m_blendPass.blendPipeline = rhi->newGraphicsPipeline();
@@ -297,10 +283,8 @@ void PostprocessingSMAA::initializePostprocessingPipeline(QRhi *rhi, QRhiCommand
     m_blendPass.blendPipeline->create();
 
     // set resolution
-    float resolution[] = { static_cast<float>(m_targetSize.width()),
-                            static_cast<float>(m_targetSize.height()) };
+    float resolution[] = { static_cast<float>(m_targetSize.width()), static_cast<float>(m_targetSize.height()) };
     resourceUpdates->updateDynamicBuffer(m_common.quadUbuffer, 0, 8, &resolution);
-
 
     qint32 flip = rhi->isYUpInFramebuffer() ? 1 : 0;
     resourceUpdates->updateDynamicBuffer(m_common.quadUbuffer, 8, 4, &flip);
@@ -308,10 +292,9 @@ void PostprocessingSMAA::initializePostprocessingPipeline(QRhi *rhi, QRhiCommand
     commandBuffer->resourceUpdate(resourceUpdates);
     m_target = m_blendPass.blendTexture;
     m_isInitialized = true;
-    
 }
 
-void PostprocessingSMAA::postprocess(QRhi* rhi, QRhiCommandBuffer* commandBuffer)
+void PostprocessingSMAA::postprocess(QRhi *rhi, QRhiCommandBuffer *commandBuffer)
 {
     if (!m_isInitialized || !m_frameTexture) {
         return;
@@ -323,8 +306,8 @@ void PostprocessingSMAA::postprocess(QRhi* rhi, QRhiCommandBuffer* commandBuffer
     commandBuffer->beginPass(m_edgesPass.edgesTarget, Qt::black, { 1.0f, 0 });
 
     commandBuffer->setGraphicsPipeline(m_edgesPass.edgesPipeline);
-    commandBuffer->setViewport({ 0, 0, float(m_edgesPass.edgesTexture->pixelSize().width()),
-                                       float(m_edgesPass.edgesTexture->pixelSize().height()) });
+    commandBuffer->setViewport(
+        { 0, 0, float(m_edgesPass.edgesTexture->pixelSize().width()), float(m_edgesPass.edgesTexture->pixelSize().height()) });
     commandBuffer->setShaderResources();
     commandBuffer->setVertexInput(0, 1, &quadBinding, m_common.quadIndexBuffer, 0, QRhiCommandBuffer::IndexUInt16);
     commandBuffer->drawIndexed(6);
@@ -333,8 +316,8 @@ void PostprocessingSMAA::postprocess(QRhi* rhi, QRhiCommandBuffer* commandBuffer
     // second postprocess pass: weights calculation
     commandBuffer->beginPass(m_weightsPass.weightsTarget, Qt::black, { 1.0f, 0 });
     commandBuffer->setGraphicsPipeline(m_weightsPass.weightsPipeline);
-    commandBuffer->setViewport({ 0, 0, float(m_weightsPass.weightsTexture->pixelSize().width()),
-                                       float(m_weightsPass.weightsTexture->pixelSize().height()) });
+    commandBuffer->setViewport(
+        { 0, 0, float(m_weightsPass.weightsTexture->pixelSize().width()), float(m_weightsPass.weightsTexture->pixelSize().height()) });
     commandBuffer->setShaderResources();
     commandBuffer->setVertexInput(0, 1, &quadBinding, m_common.quadIndexBuffer, 0, QRhiCommandBuffer::IndexUInt16);
     commandBuffer->drawIndexed(6);
@@ -343,8 +326,8 @@ void PostprocessingSMAA::postprocess(QRhi* rhi, QRhiCommandBuffer* commandBuffer
     // third postprocess pass: blending frame and weights
     commandBuffer->beginPass(m_blendPass.blendTarget, Qt::black, { 1.0f, 0 });
     commandBuffer->setGraphicsPipeline(m_blendPass.blendPipeline);
-    commandBuffer->setViewport({ 0, 0, float(m_blendPass.blendTexture->pixelSize().width()),
-                                       float(m_blendPass.blendTexture->pixelSize().height()) });
+    commandBuffer->setViewport(
+        { 0, 0, float(m_blendPass.blendTexture->pixelSize().width()), float(m_blendPass.blendTexture->pixelSize().height()) });
     commandBuffer->setShaderResources();
     commandBuffer->setVertexInput(0, 1, &quadBinding, m_common.quadIndexBuffer, 0, QRhiCommandBuffer::IndexUInt16);
     commandBuffer->drawIndexed(6);
@@ -362,28 +345,28 @@ void PostprocessingSMAA::cleanup()
         m_common.quadIndexBuffer = nullptr;
         m_common.quadUbuffer = nullptr;
 
-        m_lookup.areaTexture = nullptr ;
+        m_lookup.areaTexture = nullptr;
         m_lookup.areaSampler = nullptr;
-        m_lookup.searchTexture = nullptr ;
+        m_lookup.searchTexture = nullptr;
         m_lookup.searchSampler = nullptr;
 
         m_edgesPass.edgesRenderPassDescriptor = nullptr;
         m_edgesPass.edgesTarget = nullptr;
-        m_edgesPass.edgesTexture = nullptr ;
+        m_edgesPass.edgesTexture = nullptr;
         m_edgesPass.edgesSampler = nullptr;
         m_edgesPass.edgesResourceBindings = nullptr;
         m_edgesPass.edgesPipeline = nullptr;
 
         m_weightsPass.weightsRenderPassDescriptor = nullptr;
         m_weightsPass.weightsTarget = nullptr;
-        m_weightsPass.weightsTexture = nullptr ;
+        m_weightsPass.weightsTexture = nullptr;
         m_weightsPass.weightsSampler = nullptr;
         m_weightsPass.weightsResourceBindings = nullptr;
         m_weightsPass.weightsPipeline = nullptr;
 
         m_blendPass.blendRenderPassDescriptor = nullptr;
         m_blendPass.blendTarget = nullptr;
-        m_blendPass.blendTexture = nullptr ;
+        m_blendPass.blendTexture = nullptr;
         m_blendPass.blendResourceBindings = nullptr;
         m_blendPass.blendPipeline = nullptr;
 
@@ -393,7 +376,5 @@ void PostprocessingSMAA::cleanup()
         m_target = nullptr;
 
         m_isInitialized = false;
-
     }
-    
 }

--- a/src/RiveQtQuickItem/rhi/postprocessingsmaa.h
+++ b/src/RiveQtQuickItem/rhi/postprocessingsmaa.h
@@ -21,8 +21,8 @@ public:
     bool isInitialized() const { return m_isInitialized; }
 
     // void initializePostprocessingPipeline(QRhi *rhi, const QSizeF &size, std::weak_ptr<QRhiTexture> frameTexture);
-    void initializePostprocessingPipeline(QRhi *rhi, QRhiCommandBuffer *commandBuffer, const QSize &size, QRhiTexture *frameTexture);
-    void postprocess(QRhi *rhi, QRhiCommandBuffer *commandBuffer);
+    void initializePostprocessingPipeline(QRhi *rhi, QRhiCommandBuffer *commandBuffer, const QSize &size);
+    void postprocess(QRhi *rhi, QRhiCommandBuffer *commandBuffer, QRhiTexture *frameTexture);
     void cleanup();
 
 private:
@@ -32,9 +32,6 @@ private:
 
     bool m_isInitialized { false };
     QVector<QRhiResource *> m_releasePool;
-
-    // not owned by us (ToDo: should be a weak pointer)
-    QRhiTexture *m_frameTexture { nullptr };
 
     // owned by us
     QRhiSampler *m_frameSampler { nullptr };

--- a/src/RiveQtQuickItem/rhi/postprocessingsmaa.h
+++ b/src/RiveQtQuickItem/rhi/postprocessingsmaa.h
@@ -20,10 +20,9 @@ public:
     QRhiTexture *getTarget() const { return m_target; }
     bool isInitialized() const { return m_isInitialized; }
 
-    //void initializePostprocessingPipeline(QRhi *rhi, const QSizeF &size, std::weak_ptr<QRhiTexture> frameTexture);
-    void initializePostprocessingPipeline(QRhi *rhi, QRhiCommandBuffer* commandBuffer,
-        const QSize &size, QRhiTexture* frameTexture);
-    void postprocess(QRhi *rhi, QRhiCommandBuffer* commandBuffer);
+    // void initializePostprocessingPipeline(QRhi *rhi, const QSizeF &size, std::weak_ptr<QRhiTexture> frameTexture);
+    void initializePostprocessingPipeline(QRhi *rhi, QRhiCommandBuffer *commandBuffer, const QSize &size, QRhiTexture *frameTexture);
+    void postprocess(QRhi *rhi, QRhiCommandBuffer *commandBuffer);
     void cleanup();
 
 private:
@@ -35,31 +34,35 @@ private:
     QVector<QRhiResource *> m_releasePool;
 
     // not owned by us (ToDo: should be a weak pointer)
-    QRhiTexture* m_frameTexture { nullptr };
+    QRhiTexture *m_frameTexture { nullptr };
 
     // owned by us
-    QRhiSampler* m_frameSampler { nullptr };
-    struct {
+    QRhiSampler *m_frameSampler { nullptr };
+    struct
+    {
         QVector<QRhiShaderStage> edgePass;
         QVector<QRhiShaderStage> weightsPass;
         QVector<QRhiShaderStage> blendPass;
     } m_shaders;
 
-    struct {
+    struct
+    {
         QRhiBuffer *quadVertexBuffer = nullptr;
         QRhiBuffer *quadIndexBuffer = nullptr;
         QRhiBuffer *quadUbuffer = nullptr;
     } m_common;
 
-    struct {
+    struct
+    {
         // lookup textures for weight computation
-        QRhiTexture *areaTexture = nullptr ;
+        QRhiTexture *areaTexture = nullptr;
         QRhiSampler *areaSampler = nullptr;
-        QRhiTexture *searchTexture = nullptr ;
+        QRhiTexture *searchTexture = nullptr;
         QRhiSampler *searchSampler = nullptr;
     } m_lookup;
 
-    struct {
+    struct
+    {
         // edges target (we are going to render the edges into this texture)
         QRhiRenderPassDescriptor *edgesRenderPassDescriptor = nullptr;
         QRhiTextureRenderTarget *edgesTarget = nullptr;
@@ -71,11 +74,12 @@ private:
         QRhiGraphicsPipeline *edgesPipeline = nullptr;
     } m_edgesPass;
 
-    struct {
+    struct
+    {
         // weights target (we are going to render the weights into this texture)
         QRhiRenderPassDescriptor *weightsRenderPassDescriptor = nullptr;
         QRhiTextureRenderTarget *weightsTarget = nullptr;
-        QRhiTexture *weightsTexture = nullptr ;
+        QRhiTexture *weightsTexture = nullptr;
         QRhiSampler *weightsSampler = nullptr;
 
         // rendering pipeline for our weight calculation pass
@@ -83,11 +87,12 @@ private:
         QRhiGraphicsPipeline *weightsPipeline = nullptr;
     } m_weightsPass;
 
-    struct {
+    struct
+    {
         // blend target (this is the last pass, so we don't need a sampler for the next stage here)
         QRhiRenderPassDescriptor *blendRenderPassDescriptor = nullptr;
         QRhiTextureRenderTarget *blendTarget = nullptr;
-        QRhiTexture *blendTexture = nullptr ;
+        QRhiTexture *blendTexture = nullptr;
 
         // rendering pipeline for blending pass
         QRhiShaderResourceBindings *blendResourceBindings = nullptr;
@@ -96,5 +101,4 @@ private:
 
     QSize m_targetSize;
     QRhiTexture *m_target { nullptr };
-
 };

--- a/src/RiveQtQuickItem/rhi/texturetargetnode.cpp
+++ b/src/RiveQtQuickItem/rhi/texturetargetnode.cpp
@@ -9,37 +9,18 @@
 #include <QQuickItem>
 #include <QQuickWindow>
 #include <QSGRendererInterface>
+#include "riveqsgrhirendernode.h"
 
 #include <private/qrhi_p.h>
 #include <private/qsgrendernode_p.h>
 
-TextureTargetNode::TextureTargetNode(QQuickWindow *window, QRhiTexture *displayBuffer, const QRectF &viewPortRect,
+TextureTargetNode::TextureTargetNode(QQuickWindow *window, RiveQSGRHIRenderNode *node, const QRectF &viewPortRect,
                                      const QMatrix4x4 *combinedMatrix, const QMatrix4x4 *projectionMatrix)
     : m_combinedMatrix(combinedMatrix)
     , m_projectionMatrix(projectionMatrix)
     , m_window(window)
+    , m_node(node)
 {
-    QFile file;
-    file.setFileName(":/shaders/qt6/drawRiveTextureNode.vert.qsb");
-    file.open(QFile::ReadOnly);
-    m_pathShader.append(QRhiShaderStage(QRhiShaderStage::Vertex, QShader::fromSerialized(file.readAll())));
-
-    file.close();
-    file.setFileName(":/shaders/qt6/drawRiveTextureNode.frag.qsb");
-    file.open(QFile::ReadOnly);
-    m_pathShader.append(QRhiShaderStage(QRhiShaderStage::Fragment, QShader::fromSerialized(file.readAll())));
-
-    file.close();
-    file.setFileName(":/shaders/qt6/blendRiveTextureNode.vert.qsb");
-    file.open(QFile::ReadOnly);
-    m_blendShaders.append(QRhiShaderStage(QRhiShaderStage::Vertex, QShader::fromSerialized(file.readAll())));
-
-    file.close();
-    file.setFileName(":/shaders/qt6/blendRiveTextureNode.frag.qsb");
-    file.open(QFile::ReadOnly);
-
-    m_blendShaders.append(QRhiShaderStage(QRhiShaderStage::Fragment, QShader::fromSerialized(file.readAll())));
-
     m_blendTexCoords.append(QVector2D(0.0f, 0.0f));
     m_blendTexCoords.append(QVector2D(0.0f, 1.0f));
     m_blendTexCoords.append(QVector2D(1.0f, 0.0f));
@@ -50,13 +31,12 @@ TextureTargetNode::TextureTargetNode(QQuickWindow *window, QRhiTexture *displayB
     m_blendVertices.append(QVector2D(viewPortRect.x() + viewPortRect.width(), viewPortRect.y()));
     m_blendVertices.append(QVector2D(viewPortRect.x() + viewPortRect.width(), viewPortRect.y() + viewPortRect.height()));
 
-    m_bounds = viewPortRect;
+    m_rect = viewPortRect;
 
     auto *renderInterface = m_window->rendererInterface();
     auto *rhi = static_cast<QRhi *>(renderInterface->getResource(m_window, QSGRendererInterface::RhiResource));
 
-    Q_ASSERT(displayBuffer);
-    m_displayBuffer = displayBuffer;
+    Q_ASSERT(m_node);
 
     // TODO: make it so that we are not limited to MAX_VERTICES vertices,
     // adjust the buffer dynamically on demand
@@ -99,109 +79,8 @@ void TextureTargetNode::recycle()
     useGradient = 0;
     m_blendMode = rive::BlendMode::srcOver;
     m_opacity = 1.0f;
-
-    if (m_clip) {
-        m_clip = false;
-        if (m_clippingResourceBindings) {
-            m_cleanupList.removeAll(m_clippingResourceBindings);
-            m_clippingResourceBindings->destroy();
-            delete m_clippingResourceBindings;
-            m_clippingResourceBindings = nullptr;
-        }
-        if (m_clippingUniformBuffer) {
-            m_cleanupList.removeAll(m_clippingUniformBuffer);
-            m_clippingUniformBuffer->destroy();
-            delete m_clippingUniformBuffer;
-            m_clippingUniformBuffer = nullptr;
-        }
-        if (m_displayBufferTarget) {
-            m_cleanupList.removeAll(m_displayBufferTarget);
-            m_displayBufferTarget->destroy();
-            delete m_displayBufferTarget;
-            m_displayBufferTarget = nullptr;
-        }
-        if (m_displayBufferTargetDescriptor) {
-            m_cleanupList.removeAll(m_displayBufferTargetDescriptor);
-            m_displayBufferTargetDescriptor->destroy();
-            delete m_displayBufferTargetDescriptor;
-            m_displayBufferTargetDescriptor = nullptr;
-        }
-        if (m_clipPipeLine) {
-            m_cleanupList.removeAll(m_clipPipeLine);
-            m_clipPipeLine->destroy();
-            delete m_clipPipeLine;
-            m_clipPipeLine = nullptr;
-        }
-    }
-    if (m_shaderBlending) {
-        m_shaderBlending = false;
-        m_blendVertices.clear();
-        m_blendVertices.append(QVector2D(m_bounds.x(), m_bounds.y()));
-        m_blendVertices.append(QVector2D(m_bounds.x(), m_bounds.y() + m_bounds.height()));
-        m_blendVertices.append(QVector2D(m_bounds.x() + m_bounds.width(), m_bounds.y()));
-        m_blendVertices.append(QVector2D(m_bounds.x() + m_bounds.width(), m_bounds.y() + m_bounds.height()));
-
-        if (m_blendTextureRenderTarget) {
-            m_cleanupList.removeAll(m_blendTextureRenderTarget);
-            m_blendTextureRenderTarget->destroy();
-            delete m_blendTextureRenderTarget;
-            m_blendTextureRenderTarget = nullptr;
-        }
-        if (m_blendRenderDescriptor) {
-            m_cleanupList.removeAll(m_blendRenderDescriptor);
-            m_blendRenderDescriptor->destroy();
-            delete m_blendRenderDescriptor;
-            m_blendRenderDescriptor = nullptr;
-        }
-        if (m_blendUniformBuffer) {
-            m_cleanupList.removeAll(m_blendUniformBuffer);
-            m_blendUniformBuffer->destroy();
-            delete m_blendUniformBuffer;
-            m_blendUniformBuffer = nullptr;
-        }
-
-        if (m_blendPipeLine) {
-            m_cleanupList.removeAll(m_blendPipeLine);
-            m_blendPipeLine->destroy();
-            delete m_blendPipeLine;
-            m_blendPipeLine = nullptr;
-        }
-
-        if (m_blendVertexBuffer) {
-            m_cleanupList.removeAll(m_blendVertexBuffer);
-            m_blendVertexBuffer->destroy();
-            delete m_blendVertexBuffer;
-            m_blendVertexBuffer = nullptr;
-        }
-
-        if (m_blendSampler) {
-            m_cleanupList.removeAll(m_blendSampler);
-            m_blendSampler->destroy();
-            delete m_blendSampler;
-            m_blendSampler = nullptr;
-        }
-
-        if (m_blendResourceBindings) {
-            m_cleanupList.removeAll(m_blendResourceBindings);
-            m_blendResourceBindings->destroy();
-            delete m_blendResourceBindings;
-            m_blendResourceBindings = nullptr;
-        }
-
-        if (m_blendSrc) {
-            m_cleanupList.removeAll(m_blendSrc);
-            m_blendSrc->destroy();
-            delete m_blendSrc;
-            m_blendSrc = nullptr;
-        }
-
-        if (m_blendDest) {
-            m_cleanupList.removeAll(m_blendDest);
-            m_blendDest->destroy();
-            delete m_blendDest;
-            m_blendDest = nullptr;
-        }
-    }
+    m_clip = false;
+    m_shaderBlending = false;
 
     if (m_qImageTexture) {
         if (m_sampler) {
@@ -217,13 +96,6 @@ void TextureTargetNode::recycle()
             delete m_qImageTexture;
             m_qImageTexture = nullptr;
         }
-
-        if (m_resourceBindings) {
-            m_cleanupList.removeAll(m_resourceBindings);
-            m_resourceBindings->destroy();
-            delete m_resourceBindings;
-            m_resourceBindings = nullptr;
-        }
     }
     m_recycled = true;
 }
@@ -235,61 +107,22 @@ void TextureTargetNode::releaseResources()
         m_cleanupList.removeAll(resource);
         resource->destroy();
         delete resource;
+        resource = nullptr;
     }
-
-    m_vertexBuffer = nullptr;
-    m_clippingVertexBuffer = nullptr;
-    m_uniformBuffer = nullptr;
-    m_resourceBindings = nullptr;
-    m_displayBufferTarget = nullptr;
-    m_displayBufferTargetDescriptor = nullptr;
-
-    m_uniformBuffer = nullptr;
-    m_texCoordBuffer = nullptr;
-    m_indicesBuffer = nullptr;
-    m_clippingVertexBuffer = nullptr;
-    m_clippingUniformBuffer = nullptr;
-
-    m_clippingResourceBindings = nullptr;
-
-    m_blendPipeLine = nullptr;
-    m_clipPipeLine = nullptr;
-
-    m_blendTextureRenderTarget = nullptr;
-    m_blendRenderDescriptor = nullptr;
-
-    m_stencilClippingBuffer = nullptr;
-    m_sampler = nullptr;
-    m_qImageTexture = nullptr;
-
-    m_internalDisplayBufferTexture = nullptr;
-
-    m_blendSrc = nullptr;
-    m_blendDest = nullptr;
-
-    m_blendVertexBuffer = nullptr;
-    m_blendTexCoordBuffer = nullptr;
-    m_blendUniformBuffer = nullptr;
-    m_blendResourceBindings = nullptr;
-    m_blendSampler = nullptr;
-    m_resourceUpdates = nullptr;
-    m_blendResourceUpdates = nullptr;
 }
 
-void TextureTargetNode::updateViewport(const QRectF &bounds, QRhiTexture *displayBuffer)
+void TextureTargetNode::updateViewport(const QRectF &rect)
 {
-    m_displayBuffer = displayBuffer;
-
     releaseResources();
 
     m_blendVertices.clear();
 
-    m_blendVertices.append(QVector2D(bounds.x(), bounds.y()));
-    m_blendVertices.append(QVector2D(bounds.x(), bounds.y() + bounds.height()));
-    m_blendVertices.append(QVector2D(bounds.x() + bounds.width(), bounds.y()));
-    m_blendVertices.append(QVector2D(bounds.x() + bounds.width(), bounds.y() + bounds.height()));
+    m_blendVertices.append(QVector2D(rect.x(), rect.y()));
+    m_blendVertices.append(QVector2D(rect.x(), rect.y() + rect.height()));
+    m_blendVertices.append(QVector2D(rect.x() + rect.width(), rect.y()));
+    m_blendVertices.append(QVector2D(rect.x() + rect.width(), rect.y() + rect.height()));
 
-    m_bounds = bounds;
+    m_rect = rect;
     m_blendVerticesDirty = true;
 }
 
@@ -299,181 +132,7 @@ void TextureTargetNode::prepareRender()
     QRhi *rhi = static_cast<QRhi *>(renderInterface->getResource(m_window, QSGRendererInterface::RhiResource));
     Q_ASSERT(rhi);
 
-    // This configures our main uniform Buffer
-    if (!m_uniformBuffer) {
-        m_uniformBuffer = rhi->newBuffer(QRhiBuffer::Dynamic, QRhiBuffer::UniformBuffer, 848);
-        m_uniformBuffer->create();
-        m_cleanupList.append(m_uniformBuffer);
-    }
-
-    if (!m_resourceBindings) {
-        m_resourceBindings = rhi->newShaderResourceBindings();
-
-        if (m_qImageTexture && m_sampler) {
-            m_resourceBindings->setBindings({
-                QRhiShaderResourceBinding::uniformBuffer(
-                    0, QRhiShaderResourceBinding::VertexStage | QRhiShaderResourceBinding::FragmentStage, m_uniformBuffer),
-                QRhiShaderResourceBinding::sampledTexture(1, QRhiShaderResourceBinding::FragmentStage, m_qImageTexture, m_sampler) //
-            });
-        } else {
-            m_resourceBindings->setBindings({ QRhiShaderResourceBinding::uniformBuffer(
-                0, QRhiShaderResourceBinding::VertexStage | QRhiShaderResourceBinding::FragmentStage, m_uniformBuffer) });
-        }
-        m_resourceBindings->create();
-        m_cleanupList.append(m_resourceBindings);
-    }
-
-    if (!m_clippingUniformBuffer) {
-        m_clippingUniformBuffer = rhi->newBuffer(QRhiBuffer::Dynamic, QRhiBuffer::UniformBuffer, 848);
-        m_clippingUniformBuffer->create();
-        m_cleanupList.append(m_clippingUniformBuffer);
-    }
-
-    if (!m_clippingResourceBindings) {
-        m_clippingResourceBindings = rhi->newShaderResourceBindings();
-        m_clippingResourceBindings->setBindings({ QRhiShaderResourceBinding::uniformBuffer(
-            0, QRhiShaderResourceBinding::VertexStage | QRhiShaderResourceBinding::FragmentStage, m_clippingUniformBuffer) });
-        m_clippingResourceBindings->create();
-        m_cleanupList.append(m_clippingResourceBindings);
-    }
-
-    // we create a stencil buffer, even if clipping is not on
-    // this my change later, but note that we would need to recreate all depending elements such as the RenderTargetDescription
-    if (!m_stencilClippingBuffer) {
-        m_stencilClippingBuffer = rhi->newRenderBuffer(QRhiRenderBuffer::DepthStencil, QSize(m_bounds.width(), m_bounds.height()), 1);
-        m_stencilClippingBuffer->create();
-        m_cleanupList.append(m_stencilClippingBuffer);
-    }
-
-    if (!m_displayBufferTarget) {
-        if (!m_shaderBlending) {
-            QRhiColorAttachment colorAttachment(m_displayBuffer);
-            QRhiTextureRenderTargetDescription desc(colorAttachment);
-            desc.setDepthStencilBuffer(m_stencilClippingBuffer);
-            m_displayBufferTarget = rhi->newTextureRenderTarget(desc, QRhiTextureRenderTarget::PreserveColorContents);
-        } else {
-            if (!m_internalDisplayBufferTexture) {
-                m_internalDisplayBufferTexture = rhi->newTexture(QRhiTexture::RGBA8, QSize(m_bounds.width(), m_bounds.height()), 1,
-                                                                 QRhiTexture::RenderTarget | QRhiTexture::UsedAsTransferSource);
-                m_internalDisplayBufferTexture->create();
-                m_cleanupList.append(m_internalDisplayBufferTexture);
-            }
-
-            QRhiColorAttachment colorAttachment(m_internalDisplayBufferTexture);
-            QRhiTextureRenderTargetDescription desc(colorAttachment);
-            desc.setDepthStencilBuffer(m_stencilClippingBuffer);
-            m_displayBufferTarget = rhi->newTextureRenderTarget(desc);
-        }
-
-        m_displayBufferTarget->create();
-        m_cleanupList.append(m_displayBufferTarget);
-    }
-
     m_resourceUpdates = rhi->nextResourceUpdateBatch();
-
-    if (!m_displayBufferTargetDescriptor) {
-        m_displayBufferTargetDescriptor = m_displayBufferTarget->newCompatibleRenderPassDescriptor();
-        m_displayBufferTarget->setRenderPassDescriptor(m_displayBufferTargetDescriptor);
-        m_cleanupList.append(m_displayBufferTargetDescriptor);
-    }
-
-    if (!m_clipPipeLine) {
-        m_clipPipeLine = rhi->newGraphicsPipeline();
-
-        m_clipPipeLine->setShaderStages(m_pathShader.cbegin(), m_pathShader.cend());
-        m_clipPipeLine->setFlags(QRhiGraphicsPipeline::UsesStencilRef);
-        m_clipPipeLine->setDepthTest(true);
-        m_clipPipeLine->setDepthWrite(true);
-
-        QRhiGraphicsPipeline::TargetBlend disabledColorWrite;
-        disabledColorWrite.colorWrite = QRhiGraphicsPipeline::ColorMask(0);
-        m_clipPipeLine->setTargetBlends({ disabledColorWrite });
-
-        QRhiVertexInputLayout inputLayout;
-        inputLayout.setBindings({
-            { sizeof(QVector2D) },
-            { sizeof(QVector2D) },
-        });
-        inputLayout.setAttributes({
-            { 0, 0, QRhiVertexInputAttribute::Float2, 0 },
-            { 1, 1, QRhiVertexInputAttribute::Float2, 0 },
-        });
-
-        // Configure stencil operations for writing stencil values
-        QRhiGraphicsPipeline::StencilOpState stencilOpState = { QRhiGraphicsPipeline::Keep, QRhiGraphicsPipeline::Keep,
-                                                                QRhiGraphicsPipeline::Replace, QRhiGraphicsPipeline::Always };
-        m_clipPipeLine->setStencilFront(stencilOpState);
-        m_clipPipeLine->setStencilBack(stencilOpState);
-        m_clipPipeLine->setStencilTest(true);
-        m_clipPipeLine->setCullMode(QRhiGraphicsPipeline::None);
-        m_clipPipeLine->setTopology(QRhiGraphicsPipeline::Triangles);
-        m_clipPipeLine->setVertexInputLayout(inputLayout);
-        m_clipPipeLine->setRenderPassDescriptor(m_displayBufferTargetDescriptor);
-
-        m_clipPipeLine->setShaderResourceBindings(m_clippingResourceBindings);
-        m_clipPipeLine->create();
-        m_cleanupList.append(m_clipPipeLine);
-    }
-
-    if (m_drawPipelines.empty()) {
-        QList<rive::BlendMode> modes;
-        modes << rive::BlendMode::luminosity; // default shader based no blending
-        modes << rive::BlendMode::srcOver;
-
-        for (auto mode : modes) {
-            QRhiGraphicsPipeline *drawPipeLine = rhi->newGraphicsPipeline();
-
-            //
-            // If layer.enabled == true on our QQuickItem, the rendering face is flipped for
-            // backends with isYUpInFrameBuffer == true (OpenGL). This does not happen with
-            // RHI backends with isYUpInFrameBuffer == false. We swap the triangle winding
-            // order to work around this.
-            //
-            drawPipeLine->setFrontFace(rhi->isYUpInFramebuffer() ? QRhiGraphicsPipeline::CW : QRhiGraphicsPipeline::CCW);
-            drawPipeLine->setCullMode(QRhiGraphicsPipeline::None);
-            drawPipeLine->setTopology(QRhiGraphicsPipeline::Triangles);
-
-            if (mode == rive::BlendMode::srcOver) {
-                QRhiGraphicsPipeline::TargetBlend blend;
-                blend.enable = true;
-                blend.srcColor = QRhiGraphicsPipeline::SrcAlpha;
-                blend.dstColor = QRhiGraphicsPipeline::OneMinusSrcAlpha;
-                blend.srcAlpha = QRhiGraphicsPipeline::One;
-                blend.dstAlpha = QRhiGraphicsPipeline::OneMinusSrcAlpha;
-                drawPipeLine->setTargetBlends({ blend });
-            }
-
-            drawPipeLine->setShaderResourceBindings(m_resourceBindings);
-            drawPipeLine->setShaderStages(m_pathShader.cbegin(), m_pathShader.cend());
-
-            QRhiVertexInputLayout inputLayout;
-            inputLayout.setBindings({
-                { sizeof(QVector2D) },
-                { sizeof(QVector2D) },
-            });
-            inputLayout.setAttributes({
-                { 0, 0, QRhiVertexInputAttribute::Float2, 0 }, // Position1
-                { 1, 1, QRhiVertexInputAttribute::Float2, 0 } // Texture coordinate
-            });
-
-            drawPipeLine->setVertexInputLayout(inputLayout);
-            drawPipeLine->setRenderPassDescriptor(m_displayBufferTargetDescriptor);
-
-            QRhiGraphicsPipeline::StencilOpState stencilOpState = { QRhiGraphicsPipeline::Keep, QRhiGraphicsPipeline::Keep,
-                                                                    QRhiGraphicsPipeline::Replace, QRhiGraphicsPipeline::Equal };
-            drawPipeLine->setDepthTest(false);
-            drawPipeLine->setDepthWrite(false);
-            drawPipeLine->setStencilFront(stencilOpState);
-            drawPipeLine->setStencilBack(stencilOpState);
-            drawPipeLine->setStencilTest(true);
-            drawPipeLine->setStencilWriteMask(0);
-            drawPipeLine->setFlags(QRhiGraphicsPipeline::UsesStencilRef);
-
-            drawPipeLine->create();
-            m_cleanupList.append(drawPipeLine);
-            m_drawPipelines.insert(mode, drawPipeLine);
-        }
-    }
 
     if (m_oldBufferSize > m_geometryData.size()) {
         m_resourceUpdates->updateDynamicBuffer(m_vertexBuffer, 0,
@@ -503,6 +162,47 @@ void TextureTargetNode::prepareRender()
         m_resourceUpdates->uploadStaticBuffer(m_indicesBuffer, m_indicesData);
     }
 
+    // shared buffers / bindings will transfer information into multiple passes
+    // this is why each objects needs its own buffers
+    if (!m_drawUniformBuffer) {
+        m_drawUniformBuffer = rhi->newBuffer(QRhiBuffer::Dynamic, QRhiBuffer::UniformBuffer, 848);
+        m_drawUniformBuffer->create();
+        m_cleanupList.append(m_drawUniformBuffer);
+    }
+
+    if (!m_clippingUniformBuffer) {
+        m_clippingUniformBuffer = rhi->newBuffer(QRhiBuffer::Dynamic, QRhiBuffer::UniformBuffer, 848);
+        m_clippingUniformBuffer->create();
+        m_cleanupList.append(m_clippingUniformBuffer);
+    }
+
+    if (!m_clippingResourceBindings) {
+        m_clippingResourceBindings = rhi->newShaderResourceBindings();
+        m_clippingResourceBindings->setBindings({ QRhiShaderResourceBinding::uniformBuffer(
+            0, QRhiShaderResourceBinding::VertexStage | QRhiShaderResourceBinding::FragmentStage, m_clippingUniformBuffer) });
+        m_clippingResourceBindings->create();
+        m_cleanupList.append(m_clippingResourceBindings);
+    }
+
+    if (!m_drawPipelineResourceBindings) {
+        m_drawPipelineResourceBindings = rhi->newShaderResourceBindings();
+
+        if (m_qImageTexture && m_sampler) {
+            m_drawPipelineResourceBindings->setBindings({
+                QRhiShaderResourceBinding::uniformBuffer(
+                    0, QRhiShaderResourceBinding::VertexStage | QRhiShaderResourceBinding::FragmentStage, m_drawUniformBuffer),
+                QRhiShaderResourceBinding::sampledTexture(1, QRhiShaderResourceBinding::FragmentStage, m_qImageTexture, m_sampler) //
+            });
+        } else {
+            m_drawPipelineResourceBindings->setBindings({ QRhiShaderResourceBinding::uniformBuffer(
+                0, QRhiShaderResourceBinding::VertexStage | QRhiShaderResourceBinding::FragmentStage, m_drawUniformBuffer) });
+        }
+        m_drawPipelineResourceBindings->create();
+        m_cleanupList.append(m_drawPipelineResourceBindings);
+    }
+
+    auto *uniformBuffer = m_drawUniformBuffer;
+
     // now we setup the shader to draw the path
     float opacity = m_opacity;
 
@@ -513,28 +213,28 @@ void TextureTargetNode::prepareRender()
     m_resourceUpdates->updateDynamicBuffer(m_clippingUniformBuffer, 0, 64, (*m_combinedMatrix).constData());
     m_resourceUpdates->updateDynamicBuffer(m_clippingUniformBuffer, 784, 64, QMatrix4x4().constData());
 
-    m_resourceUpdates->updateDynamicBuffer(m_uniformBuffer, 0, 64, (*m_combinedMatrix).constData());
-    m_resourceUpdates->updateDynamicBuffer(m_uniformBuffer, 784, 64, m_transform.constData());
-    m_resourceUpdates->updateDynamicBuffer(m_uniformBuffer, 64, 4, &opacity);
-    m_resourceUpdates->updateDynamicBuffer(m_uniformBuffer, 76, 4, &useTexture);
+    m_resourceUpdates->updateDynamicBuffer(m_drawUniformBuffer, 0, 64, (*m_combinedMatrix).constData());
+    m_resourceUpdates->updateDynamicBuffer(m_drawUniformBuffer, 784, 64, m_transform.constData());
+    m_resourceUpdates->updateDynamicBuffer(m_drawUniformBuffer, 64, 4, &opacity);
+    m_resourceUpdates->updateDynamicBuffer(m_drawUniformBuffer, 76, 4, &useTexture);
 
     int useGradient = m_gradient != nullptr ? 1 : 0; // 72
-    m_resourceUpdates->updateDynamicBuffer(m_uniformBuffer, 72, 4, &useGradient);
+    m_resourceUpdates->updateDynamicBuffer(m_drawUniformBuffer, 72, 4, &useGradient);
 
     if (m_gradient) {
         QVector<QColor> gradientColors; // 144
         QVector<QVector2D> gradientPositions; // 464
-        m_resourceUpdates->updateDynamicBuffer(m_uniformBuffer, 116, 4, &m_gradientData.gradientType);
-        m_resourceUpdates->updateDynamicBuffer(m_uniformBuffer, 68, 4, &m_gradientData.gradientRadius);
-        m_resourceUpdates->updateDynamicBuffer(m_uniformBuffer, 80, 4, &m_gradientData.gradientFocalPointX);
-        m_resourceUpdates->updateDynamicBuffer(m_uniformBuffer, 84, 4, &m_gradientData.gradientFocalPointY);
-        m_resourceUpdates->updateDynamicBuffer(m_uniformBuffer, 88, 4, &m_gradientData.gradientCenterX);
-        m_resourceUpdates->updateDynamicBuffer(m_uniformBuffer, 92, 4, &m_gradientData.gradientCenterY);
-        m_resourceUpdates->updateDynamicBuffer(m_uniformBuffer, 96, 4, &m_gradientData.startPointX);
-        m_resourceUpdates->updateDynamicBuffer(m_uniformBuffer, 100, 4, &m_gradientData.startPointY);
-        m_resourceUpdates->updateDynamicBuffer(m_uniformBuffer, 104, 4, &m_gradientData.endPointX);
-        m_resourceUpdates->updateDynamicBuffer(m_uniformBuffer, 108, 4, &m_gradientData.endPointY);
-        m_resourceUpdates->updateDynamicBuffer(m_uniformBuffer, 112, 4, &m_gradientData.numberOfStops);
+        m_resourceUpdates->updateDynamicBuffer(m_drawUniformBuffer, 116, 4, &m_gradientData.gradientType);
+        m_resourceUpdates->updateDynamicBuffer(m_drawUniformBuffer, 68, 4, &m_gradientData.gradientRadius);
+        m_resourceUpdates->updateDynamicBuffer(m_drawUniformBuffer, 80, 4, &m_gradientData.gradientFocalPointX);
+        m_resourceUpdates->updateDynamicBuffer(m_drawUniformBuffer, 84, 4, &m_gradientData.gradientFocalPointY);
+        m_resourceUpdates->updateDynamicBuffer(m_drawUniformBuffer, 88, 4, &m_gradientData.gradientCenterX);
+        m_resourceUpdates->updateDynamicBuffer(m_drawUniformBuffer, 92, 4, &m_gradientData.gradientCenterY);
+        m_resourceUpdates->updateDynamicBuffer(m_drawUniformBuffer, 96, 4, &m_gradientData.startPointX);
+        m_resourceUpdates->updateDynamicBuffer(m_drawUniformBuffer, 100, 4, &m_gradientData.startPointY);
+        m_resourceUpdates->updateDynamicBuffer(m_drawUniformBuffer, 104, 4, &m_gradientData.endPointX);
+        m_resourceUpdates->updateDynamicBuffer(m_drawUniformBuffer, 108, 4, &m_gradientData.endPointY);
+        m_resourceUpdates->updateDynamicBuffer(m_drawUniformBuffer, 112, 4, &m_gradientData.numberOfStops);
 
         int startStopColorsOffset = 144;
         int gradientPositionsOffset = 464;
@@ -543,16 +243,16 @@ void TextureTargetNode::prepareRender()
             float g = m_gradientData.gradientColors[i].greenF();
             float b = m_gradientData.gradientColors[i].blueF();
             float a = m_gradientData.gradientColors[i].alphaF();
-            m_resourceUpdates->updateDynamicBuffer(m_uniformBuffer, startStopColorsOffset, 4, &r);
-            m_resourceUpdates->updateDynamicBuffer(m_uniformBuffer, startStopColorsOffset + 4, 4, &g);
-            m_resourceUpdates->updateDynamicBuffer(m_uniformBuffer, startStopColorsOffset + 8, 4, &b);
-            m_resourceUpdates->updateDynamicBuffer(m_uniformBuffer, startStopColorsOffset + 12, 4, &a);
+            m_resourceUpdates->updateDynamicBuffer(m_drawUniformBuffer, startStopColorsOffset, 4, &r);
+            m_resourceUpdates->updateDynamicBuffer(m_drawUniformBuffer, startStopColorsOffset + 4, 4, &g);
+            m_resourceUpdates->updateDynamicBuffer(m_drawUniformBuffer, startStopColorsOffset + 8, 4, &b);
+            m_resourceUpdates->updateDynamicBuffer(m_drawUniformBuffer, startStopColorsOffset + 12, 4, &a);
             startStopColorsOffset += 16;
 
             float x = m_gradientData.gradientPositions[i].x();
             float y = m_gradientData.gradientPositions[i].y();
-            m_resourceUpdates->updateDynamicBuffer(m_uniformBuffer, gradientPositionsOffset, 4, &x);
-            m_resourceUpdates->updateDynamicBuffer(m_uniformBuffer, gradientPositionsOffset + 4, 4, &y);
+            m_resourceUpdates->updateDynamicBuffer(m_drawUniformBuffer, gradientPositionsOffset, 4, &x);
+            m_resourceUpdates->updateDynamicBuffer(m_drawUniformBuffer, gradientPositionsOffset + 4, 4, &y);
             gradientPositionsOffset += 16;
         }
     } else {
@@ -560,10 +260,10 @@ void TextureTargetNode::prepareRender()
         float g = m_color.greenF();
         float b = m_color.blueF();
         float a = m_color.alphaF();
-        m_resourceUpdates->updateDynamicBuffer(m_uniformBuffer, 128, 4, &r);
-        m_resourceUpdates->updateDynamicBuffer(m_uniformBuffer, 132, 4, &g);
-        m_resourceUpdates->updateDynamicBuffer(m_uniformBuffer, 136, 4, &b);
-        m_resourceUpdates->updateDynamicBuffer(m_uniformBuffer, 140, 4, &a);
+        m_resourceUpdates->updateDynamicBuffer(m_drawUniformBuffer, 128, 4, &r);
+        m_resourceUpdates->updateDynamicBuffer(m_drawUniformBuffer, 132, 4, &g);
+        m_resourceUpdates->updateDynamicBuffer(m_drawUniformBuffer, 136, 4, &b);
+        m_resourceUpdates->updateDynamicBuffer(m_drawUniformBuffer, 140, 4, &a);
     }
 }
 
@@ -579,51 +279,58 @@ void TextureTargetNode::render(QRhiCommandBuffer *commandBuffer)
 
     prepareRender();
 
-    commandBuffer->beginPass(m_displayBufferTarget, QColor(0, 0, 0, 0), { 1.0f, 0 }, m_resourceUpdates);
+    auto *currentDisplayBufferTarget = m_node->currentRenderTarget(m_shaderBlending);
+    auto *clipPipeline = m_node->clippingPipeline();
+    auto *drawPipeline = m_node->renderPipeline(m_shaderBlending);
 
-    const QSize &renderTargetSize = m_displayBufferTarget->pixelSize();
+    // it seems we can alter the pass descriptor (we cant change blendmodes or such)
+    drawPipeline->setRenderPassDescriptor(m_node->currentRenderPassDescriptor(m_shaderBlending));
+    clipPipeline->setRenderPassDescriptor(m_node->currentRenderPassDescriptor(m_shaderBlending));
 
-    if (m_clip) {
-        // Pass 1
-        commandBuffer->setGraphicsPipeline(m_clipPipeLine);
-        commandBuffer->setStencilRef(1);
+    commandBuffer->beginPass(currentDisplayBufferTarget, QColor(0, 0, 0, 0), { 1.0f, 0 }, m_resourceUpdates);
+    {
+        const QSize renderTargetSize = currentDisplayBufferTarget->pixelSize();
+
+        if (m_clip) {
+            commandBuffer->setGraphicsPipeline(clipPipeline);
+            commandBuffer->setStencilRef(1);
+            commandBuffer->setViewport(QRhiViewport(0, 0, renderTargetSize.width(), renderTargetSize.height()));
+            commandBuffer->setShaderResources(m_clippingResourceBindings);
+            QRhiCommandBuffer::VertexInput clipVertexBindings[] = { { m_clippingVertexBuffer, 0 } };
+            commandBuffer->setVertexInput(0, 1, clipVertexBindings);
+            commandBuffer->draw(m_clippingData.size() / sizeof(QVector2D));
+            commandBuffer->setStencilRef(0);
+        }
+
+        commandBuffer->setGraphicsPipeline(drawPipeline);
         commandBuffer->setViewport(QRhiViewport(0, 0, renderTargetSize.width(), renderTargetSize.height()));
-        commandBuffer->setShaderResources(m_clippingResourceBindings);
-        QRhiCommandBuffer::VertexInput clipVertexBindings[] = { { m_clippingVertexBuffer, 0 } };
-        commandBuffer->setVertexInput(0, 1, clipVertexBindings);
-        commandBuffer->draw(m_clippingData.size() / sizeof(QVector2D));
-        commandBuffer->setStencilRef(0);
+        commandBuffer->setShaderResources(m_drawPipelineResourceBindings);
+
+        if (m_qImageTexture && m_indicesBuffer && m_texCoordBuffer) {
+            QRhiCommandBuffer::VertexInput vertexBindings[] = { { m_vertexBuffer, 0 }, { m_texCoordBuffer, 0 } };
+            commandBuffer->setVertexInput(0, 2, vertexBindings, m_indicesBuffer, 0, QRhiCommandBuffer::IndexUInt16);
+        } else {
+            QRhiCommandBuffer::VertexInput vertexBindings[] = { { m_vertexBuffer, 0 } };
+            commandBuffer->setVertexInput(0, 1, vertexBindings);
+        }
+
+        if (m_clip) {
+            commandBuffer->setStencilRef(1);
+        } else {
+            commandBuffer->setStencilRef(0);
+        }
+
+        if (m_qImageTexture && m_indicesBuffer) {
+            commandBuffer->drawIndexed(m_indicesBuffer->size() / sizeof(uint16_t));
+        } else {
+            commandBuffer->draw(m_geometryData.size() / sizeof(QVector2D));
+        }
     }
-
-    // Pass 2
-    // todo: do not use luminosity mode as "default for shader"
-    commandBuffer->setGraphicsPipeline(m_drawPipelines.value(m_blendMode, m_drawPipelines.value(rive::BlendMode::luminosity)));
-    commandBuffer->setViewport(QRhiViewport(0, 0, renderTargetSize.width(), renderTargetSize.height()));
-    commandBuffer->setShaderResources(m_resourceBindings);
-
-    if (m_qImageTexture && m_indicesBuffer && m_texCoordBuffer) {
-        QRhiCommandBuffer::VertexInput vertexBindings[] = { { m_vertexBuffer, 0 }, { m_texCoordBuffer, 0 } };
-        commandBuffer->setVertexInput(0, 2, vertexBindings, m_indicesBuffer, 0, QRhiCommandBuffer::IndexUInt16);
-    } else {
-        QRhiCommandBuffer::VertexInput vertexBindings[] = { { m_vertexBuffer, 0 } };
-        commandBuffer->setVertexInput(0, 1, vertexBindings);
-    }
-
-    if (m_clip) {
-        commandBuffer->setStencilRef(1);
-    } else {
-        commandBuffer->setStencilRef(0);
-    }
-
-    if (m_qImageTexture && m_indicesBuffer) {
-        commandBuffer->drawIndexed(m_indicesBuffer->size() / sizeof(uint16_t));
-    } else {
-        commandBuffer->draw(m_geometryData.size() / sizeof(QVector2D));
-    }
-
     commandBuffer->endPass();
 
-    renderBlend(commandBuffer);
+    if (m_shaderBlending) {
+        renderBlend(commandBuffer);
+    }
 }
 
 void TextureTargetNode::renderBlend(QRhiCommandBuffer *cb)
@@ -634,159 +341,128 @@ void TextureTargetNode::renderBlend(QRhiCommandBuffer *cb)
     QRhi *rhi = static_cast<QRhi *>(renderInterface->getResource(m_window, QSGRendererInterface::RhiResource));
     Q_ASSERT(rhi);
 
-    if (m_shaderBlending) {
-        m_blendResourceUpdates = rhi->nextResourceUpdateBatch();
+    m_blendResourceUpdates = rhi->nextResourceUpdateBatch();
 
-        if (m_blendVerticesDirty) {
-            if (m_blendVertexBuffer) {
-                m_cleanupList.removeAll(m_blendVertexBuffer);
-                m_blendVertexBuffer->destroy();
-                delete m_blendVertexBuffer;
-                m_blendVertexBuffer = nullptr;
-            }
-            m_blendVerticesDirty = false;
+    if (m_blendVerticesDirty) {
+        if (m_blendVertexBuffer) {
+            m_cleanupList.removeAll(m_blendVertexBuffer);
+            m_blendVertexBuffer->destroy();
+            delete m_blendVertexBuffer;
+            m_blendVertexBuffer = nullptr;
         }
+        m_blendVerticesDirty = false;
+    }
 
-        if (!m_blendSrc) {
-            m_blendSrc = rhi->newTexture(QRhiTexture::RGBA8, QSize(m_bounds.width(), m_bounds.height()), 1,
-                                         QRhiTexture::RenderTarget | QRhiTexture::UsedAsTransferSource);
-            m_blendSrc->create();
-            m_cleanupList.append(m_blendSrc);
-        }
-        m_blendResourceUpdates->copyTexture(m_blendSrc, m_displayBuffer);
+    if (!m_blendVertexBuffer) {
+        int blendVertexCount = m_blendVertices.count();
 
-        if (!m_blendDest) {
-            m_blendDest = rhi->newTexture(QRhiTexture::RGBA8, QSize(m_bounds.width(), m_bounds.height()), 1,
-                                          QRhiTexture::RenderTarget | QRhiTexture::UsedAsTransferSource);
-            m_blendDest->create();
-            m_cleanupList.append(m_blendDest);
-        }
+        int blendPositionBufferSize = blendVertexCount * sizeof(QVector2D);
+        m_blendVertexBuffer = rhi->newBuffer(QRhiBuffer::Immutable, QRhiBuffer::VertexBuffer, blendPositionBufferSize);
+        m_cleanupList.append(m_blendVertexBuffer);
+        m_blendVertexBuffer->create();
 
-        if (m_blendDest && m_internalDisplayBufferTexture) {
-            m_blendResourceUpdates->copyTexture(m_blendDest, m_internalDisplayBufferTexture);
-        }
+        QByteArray blendPositionData;
+        blendPositionData.resize(blendPositionBufferSize);
+        memcpy(blendPositionData.data(), m_blendVertices.constData(), blendPositionBufferSize);
+        m_blendResourceUpdates->uploadStaticBuffer(m_blendVertexBuffer, blendPositionData);
 
-        if (!m_blendTextureRenderTarget) {
-            QRhiColorAttachment colorAttachment(m_displayBuffer);
+        int blendTexCoordBufferSize = blendVertexCount * sizeof(QVector2D);
+        m_blendTexCoordBuffer = rhi->newBuffer(QRhiBuffer::Immutable, QRhiBuffer::VertexBuffer, blendTexCoordBufferSize);
+        m_cleanupList.append(m_blendTexCoordBuffer);
+        m_blendTexCoordBuffer->create();
 
-            QRhiTextureRenderTargetDescription desc(colorAttachment);
-            // desc.setDepthStencilBuffer(m_stencilClippingBuffer);
-            m_blendTextureRenderTarget = rhi->newTextureRenderTarget(desc);
+        QByteArray blendTexCoordData;
+        blendTexCoordData.resize(blendTexCoordBufferSize);
+        memcpy(blendTexCoordData.data(), m_blendTexCoords.constData(), blendTexCoordBufferSize);
+        m_blendResourceUpdates->uploadStaticBuffer(m_blendTexCoordBuffer, blendTexCoordData);
+    }
 
-            m_cleanupList.append(m_blendTextureRenderTarget);
-            m_blendTextureRenderTarget->create();
-        }
+    if (!m_blendSampler) {
+        m_blendSampler = rhi->newSampler(QRhiSampler::Linear, QRhiSampler::Linear, QRhiSampler::None, QRhiSampler::ClampToEdge,
+                                         QRhiSampler::ClampToEdge);
+        m_cleanupList.append(m_blendSampler);
+        m_blendSampler->create();
+    }
 
-        if (!m_blendRenderDescriptor) {
-            m_blendRenderDescriptor = m_blendTextureRenderTarget->newCompatibleRenderPassDescriptor();
-            m_blendTextureRenderTarget->setRenderPassDescriptor(m_blendRenderDescriptor);
-            m_cleanupList.append(m_blendRenderDescriptor);
-        }
+    if (m_blendResourceBindingsA) {
+        m_cleanupList.removeAll(m_blendResourceBindingsA);
+        m_blendResourceBindingsA->destroy();
+        delete m_blendResourceBindingsA;
+        m_blendResourceBindingsA = nullptr;
+    }
 
-        if (!m_blendVertexBuffer) {
-            int blendVertexCount = m_blendVertices.count();
+    if (m_blendResourceBindingsB) {
+        m_cleanupList.removeAll(m_blendResourceBindingsB);
+        m_blendResourceBindingsB->destroy();
+        delete m_blendResourceBindingsB;
+        m_blendResourceBindingsB = nullptr;
+    }
 
-            int blendPositionBufferSize = blendVertexCount * sizeof(QVector2D);
-            m_blendVertexBuffer = rhi->newBuffer(QRhiBuffer::Immutable, QRhiBuffer::VertexBuffer, blendPositionBufferSize);
-            m_cleanupList.append(m_blendVertexBuffer);
-            m_blendVertexBuffer->create();
+    if (!m_blendUniformBuffer) {
+        m_blendUniformBuffer = rhi->newBuffer(QRhiBuffer::Dynamic, QRhiBuffer::UniformBuffer, 80);
+        m_cleanupList.append(m_blendUniformBuffer);
+        m_blendUniformBuffer->create();
+    }
 
-            QByteArray blendPositionData;
-            blendPositionData.resize(blendPositionBufferSize);
-            memcpy(blendPositionData.data(), m_blendVertices.constData(), blendPositionBufferSize);
-            m_blendResourceUpdates->uploadStaticBuffer(m_blendVertexBuffer, blendPositionData);
+    if (!m_blendResourceBindingsA) {
+        m_blendResourceBindingsA = rhi->newShaderResourceBindings();
+        m_blendResourceBindingsA->setBindings({
+            QRhiShaderResourceBinding::uniformBuffer(0, QRhiShaderResourceBinding::VertexStage | QRhiShaderResourceBinding::FragmentStage,
+                                                     m_blendUniformBuffer),
+            QRhiShaderResourceBinding::sampledTexture(1, QRhiShaderResourceBinding::FragmentStage, m_node->getRenderBufferB(),
+                                                      m_blendSampler),
+            QRhiShaderResourceBinding::sampledTexture(2, QRhiShaderResourceBinding::FragmentStage, m_node->getRenderBufferIntern(),
+                                                      m_blendSampler),
+        });
 
-            int blendTexCoordBufferSize = blendVertexCount * sizeof(QVector2D);
-            m_blendTexCoordBuffer = rhi->newBuffer(QRhiBuffer::Immutable, QRhiBuffer::VertexBuffer, blendTexCoordBufferSize);
-            m_cleanupList.append(m_blendTexCoordBuffer);
-            m_blendTexCoordBuffer->create();
+        m_blendResourceBindingsA->create();
+        m_cleanupList.append(m_blendResourceBindingsA);
+    }
 
-            QByteArray blendTexCoordData;
-            blendTexCoordData.resize(blendTexCoordBufferSize);
-            memcpy(blendTexCoordData.data(), m_blendTexCoords.constData(), blendTexCoordBufferSize);
-            m_blendResourceUpdates->uploadStaticBuffer(m_blendTexCoordBuffer, blendTexCoordData);
-        }
+    if (!m_blendResourceBindingsB) {
+        m_blendResourceBindingsB = rhi->newShaderResourceBindings();
+        m_blendResourceBindingsB->setBindings({
+            QRhiShaderResourceBinding::uniformBuffer(0, QRhiShaderResourceBinding::VertexStage | QRhiShaderResourceBinding::FragmentStage,
+                                                     m_blendUniformBuffer),
+            QRhiShaderResourceBinding::sampledTexture(1, QRhiShaderResourceBinding::FragmentStage, m_node->getRenderBufferA(),
+                                                      m_blendSampler),
+            QRhiShaderResourceBinding::sampledTexture(2, QRhiShaderResourceBinding::FragmentStage, m_node->getRenderBufferIntern(),
+                                                      m_blendSampler),
+        });
 
-        if (!m_blendSampler) {
-            m_blendSampler = rhi->newSampler(QRhiSampler::Nearest, QRhiSampler::Nearest, QRhiSampler::None, QRhiSampler::ClampToEdge,
-                                             QRhiSampler::ClampToEdge);
-            m_cleanupList.append(m_blendSampler);
-            m_blendSampler->create();
-        }
+        m_blendResourceBindingsB->create();
+        m_cleanupList.append(m_blendResourceBindingsB);
+    }
 
-        if (!m_blendUniformBuffer) {
-            m_blendUniformBuffer = rhi->newBuffer(QRhiBuffer::Dynamic, QRhiBuffer::UniformBuffer, 80);
-            m_cleanupList.append(m_blendUniformBuffer);
-            m_blendUniformBuffer->create();
-        }
+    // swap buffer
+    m_node->switchCurrentRenderBuffer();
 
-        if (!m_blendResourceBindings) {
-            m_blendResourceBindings = rhi->newShaderResourceBindings();
-            m_blendResourceBindings->setBindings({
-                QRhiShaderResourceBinding::uniformBuffer(
-                    0, QRhiShaderResourceBinding::VertexStage | QRhiShaderResourceBinding::FragmentStage, m_blendUniformBuffer),
-                QRhiShaderResourceBinding::sampledTexture(1, QRhiShaderResourceBinding::FragmentStage, m_blendSrc, m_blendSampler),
-                QRhiShaderResourceBinding::sampledTexture(2, QRhiShaderResourceBinding::FragmentStage, m_blendDest, m_blendSampler),
-            });
+    QMatrix4x4 mvp = (*m_projectionMatrix);
+    mvp.translate(-m_rect.x(), -m_rect.y());
+    int flipped = rhi->isYUpInFramebuffer() ? 1 : 0;
+    m_blendResourceUpdates->updateDynamicBuffer(m_blendUniformBuffer, 0, 64, mvp.constData());
+    m_blendResourceUpdates->updateDynamicBuffer(m_blendUniformBuffer, 64, 4, &m_blendMode);
+    m_blendResourceUpdates->updateDynamicBuffer(m_blendUniformBuffer, 68, 4, &flipped);
 
-            m_blendResourceBindings->create();
-            m_cleanupList.append(m_blendResourceBindings);
-        }
+    auto *currentDisplayBufferTarget = m_node->currentBlendTarget();
+    auto *blendPipeline = m_node->currentBlendPipeline();
+    auto *blendResourceBindings = m_node->isCurrentRenderBufferA() ? m_blendResourceBindingsA : m_blendResourceBindingsB;
 
-        if (!m_blendPipeLine) {
-            m_blendPipeLine = rhi->newGraphicsPipeline();
-            m_cleanupList.append(m_blendPipeLine);
-            //
-            // If layer.enabled == true on our QQuickItem, the rendering face is flipped for
-            // backends with isYUpInFrameBuffer == true (OpenGL). This does not happen with
-            // RHI backends with isYUpInFrameBuffer == false. We swap the triangle winding
-            // order to work around this.
-            //
-            m_blendPipeLine->setFrontFace(rhi->isYUpInFramebuffer() ? QRhiGraphicsPipeline::CW : QRhiGraphicsPipeline::CCW);
-            m_blendPipeLine->setCullMode(QRhiGraphicsPipeline::None);
-            m_blendPipeLine->setTopology(QRhiGraphicsPipeline::TriangleStrip);
+    blendPipeline->setRenderPassDescriptor(m_node->currentBlendPassDescriptor());
 
-            m_blendPipeLine->setStencilTest(false);
-            m_blendPipeLine->setShaderResourceBindings(m_blendResourceBindings);
-            m_blendPipeLine->setShaderStages(m_blendShaders.cbegin(), m_blendShaders.cend());
+    cb->beginPass(currentDisplayBufferTarget, QColor(0, 0, 0, 0), { 1.0f, 0 }, m_blendResourceUpdates);
+    {
+        QSize blendRenderTargetSize = currentDisplayBufferTarget->pixelSize();
 
-            QRhiVertexInputLayout inputLayout;
-            inputLayout.setBindings({
-                { sizeof(QVector2D) },
-                { sizeof(QVector2D) },
-            });
-            inputLayout.setAttributes({
-                { 0, 0, QRhiVertexInputAttribute::Float2, 0 }, // Position1
-                { 1, 1, QRhiVertexInputAttribute::Float2, 0 } // Texture coordinate
-            });
-
-            m_blendPipeLine->setVertexInputLayout(inputLayout);
-            m_blendPipeLine->setRenderPassDescriptor(m_blendRenderDescriptor);
-
-            m_blendPipeLine->create();
-        }
-
-        if (m_shaderBlending) {
-            QMatrix4x4 mvp = (*m_projectionMatrix);
-            mvp.translate(-m_bounds.x(), -m_bounds.y());
-            int flipped = rhi->isYUpInFramebuffer() ? 1 : 0;
-            m_blendResourceUpdates->updateDynamicBuffer(m_blendUniformBuffer, 0, 64, mvp.constData());
-            m_blendResourceUpdates->updateDynamicBuffer(m_blendUniformBuffer, 64, 4, &m_blendMode);
-            m_blendResourceUpdates->updateDynamicBuffer(m_blendUniformBuffer, 68, 4, &flipped);
-        }
-
-        cb->beginPass(m_blendTextureRenderTarget, QColor(0, 0, 0, 0), { 1.0f, 0 }, m_blendResourceUpdates);
-        QSize blendRenderTargetSize = m_blendTextureRenderTarget->pixelSize();
-
-        cb->setGraphicsPipeline(m_blendPipeLine);
+        cb->setGraphicsPipeline(blendPipeline);
         cb->setViewport(QRhiViewport(0, 0, blendRenderTargetSize.width(), blendRenderTargetSize.height()));
-        cb->setShaderResources(m_blendResourceBindings);
+        cb->setShaderResources(blendResourceBindings);
         QRhiCommandBuffer::VertexInput blendVertexBindings[] = { { m_blendVertexBuffer, 0 }, { m_blendTexCoordBuffer, 0 } };
         cb->setVertexInput(0, 2, blendVertexBindings);
 
         cb->draw(m_blendVertices.count());
-        cb->endPass();
     }
+    cb->endPass();
 }
 
 void TextureTargetNode::setColor(const QColor &color)
@@ -857,12 +533,12 @@ void TextureTargetNode::setTexture(const QImage &image, RiveQtBufferF32 *qtVerti
             m_qImageTexture = nullptr;
         }
 
-        if (m_resourceBindings) {
-            m_cleanupList.removeAll(m_resourceBindings);
-            m_resourceBindings->destroy();
-            delete m_resourceBindings;
-            m_resourceBindings = nullptr;
-        }
+        //        if (m_resourceBindings) {
+        //            m_cleanupList.removeAll(m_resourceBindings);
+        //            m_resourceBindings->destroy();
+        //            delete m_resourceBindings;
+        //            m_resourceBindings = nullptr;
+        //        }
     }
 
     m_texture = image;
@@ -983,12 +659,6 @@ void TextureTargetNode::setTexture(const QImage &image, RiveQtBufferF32 *qtVerti
 
 void TextureTargetNode::setBlendMode(rive::BlendMode blendMode)
 {
-    if (m_blendMode == blendMode) {
-        return;
-    }
-
-    bool lastShaderBlending = m_shaderBlending;
-
     switch (blendMode) {
     case rive::BlendMode::colorDodge:
     case rive::BlendMode::overlay:
@@ -1013,36 +683,6 @@ void TextureTargetNode::setBlendMode(rive::BlendMode blendMode)
         m_blendMode = rive::BlendMode::srcOver;
         m_shaderBlending = false;
         break;
-    }
-
-    if (lastShaderBlending != m_shaderBlending) {
-        if (m_blendPipeLine) {
-            m_cleanupList.removeAll(m_blendPipeLine);
-            m_blendPipeLine->destroy();
-            delete m_blendPipeLine;
-            m_blendPipeLine = nullptr;
-        }
-
-        if (m_stencilClippingBuffer) {
-            m_cleanupList.removeAll(m_stencilClippingBuffer);
-            m_stencilClippingBuffer->destroy();
-            delete m_stencilClippingBuffer;
-            m_stencilClippingBuffer = nullptr;
-        }
-
-        if (m_displayBufferTarget) {
-            m_cleanupList.removeAll(m_displayBufferTarget);
-            m_displayBufferTarget->destroy();
-            delete m_displayBufferTarget;
-            m_displayBufferTarget = nullptr;
-        }
-
-        if (m_displayBufferTargetDescriptor) {
-            m_cleanupList.removeAll(m_displayBufferTargetDescriptor);
-            m_displayBufferTargetDescriptor->destroy();
-            delete m_displayBufferTargetDescriptor;
-            m_displayBufferTargetDescriptor = nullptr;
-        }
     }
 }
 

--- a/src/RiveQtQuickItem/riveqsgrhirendernode.h
+++ b/src/RiveQtQuickItem/riveqsgrhirendernode.h
@@ -91,9 +91,8 @@ protected:
     // shared clipping buffer for all surfaces
     QRhiRenderBuffer *m_stencilClippingBuffer { nullptr };
 
-    // those bind the texture of surfaceA and B for the final draw call
-    QRhiShaderResourceBindings *m_finalDrawResourceBindingsA { nullptr };
-    QRhiShaderResourceBindings *m_finalDrawResourceBindingsB { nullptr };
+    // those bind the texture for the final draw call
+    QRhiShaderResourceBindings *m_finalDrawResourceBindings { nullptr };
 
     // in order to configure our pipelines we have to provide resourceBindings
     // those are empty - the actual bindings are created/set per texturenode

--- a/src/RiveQtQuickItem/shaders/qt6/blendRiveTextureNode.frag
+++ b/src/RiveQtQuickItem/shaders/qt6/blendRiveTextureNode.frag
@@ -12,6 +12,7 @@ layout(location = 0) in vec2 texCoord;
 layout(std140, binding = 0) uniform buf {
     mat4 qt_Matrix;
     int blendMode;
+    int flipped;
 };
 
 layout(binding = 1) uniform sampler2D u_texture_src;
@@ -329,10 +330,11 @@ vec4 blend(vec4 srcColor, vec4 destColor, int blendMode) {
 
 void main()
 {
-   vec4 srcColor = texture(u_texture_src, texCoord);
-   vec4 destColor = texture(u_texture_dest, texCoord);
-   vec4 finalColor = blend(srcColor, destColor, blendMode);
+    vec4 srcColor = texture(u_texture_src, texCoord);
+    vec4 destColor = texture(u_texture_dest, texCoord);
 
-   //finalColor.a = 1.0f;
-   fragColor = finalColor;
+    vec4 finalColor = blend(srcColor, destColor, blendMode);
+
+    //finalColor.a = 1.0f;
+    fragColor = finalColor; //finalColor;
 }


### PR DESCRIPTION
refactor rhi drawing. no more texture copies, no more creation of pipelines per texture node. 

This provides a **significant** performance improvement already on debug builds (3fps -> 50-60fps on the same scene). It also enables 4k rendering on Desktop without performance issues.

Will be the base for MSAAx4 rendering - (did a short test, it works but has issues in the blending shaders)

**_However, more important:_** this breaks SMAA postprocessing towards crashing in Direct3D Code. 

@BertholdKrevert can you take a look at it? 
