### PR TITLE
Use correct texture for blending

### DIFF
--- a/src/RiveQtQuickItem/rhi/postprocessingsmaa.h
+++ b/src/RiveQtQuickItem/rhi/postprocessingsmaa.h
@@ -96,7 +96,8 @@ private:
         QRhiTexture *blendTexture { nullptr };
 
         // rendering pipeline for blending pass
-        QRhiShaderResourceBindings *blendResourceBindings { nullptr };
+        QRhiShaderResourceBindings *blendResourceBindingsA { nullptr };
+        QRhiShaderResourceBindings *blendResourceBindingsB { nullptr };
         QRhiGraphicsPipeline *blendPipeline { nullptr };
     } m_blendPass;
 


### PR DESCRIPTION
This fixes the problem that sometimes parts of the scene are not rendered when smaa is enabled: The smaa blend pass samples from an outdated texture.