### PR TITLE
Building on Windows

### DIFF
--- a/3rdParty/rive/cmake/CMakeLists.txt
+++ b/3rdParty/rive/cmake/CMakeLists.txt
@@ -70,7 +70,7 @@ extract_zip("${RIVE_CPP_DOWNLOAD_DIR}/rive-cpp.zip" "${RIVE_CPP_SOURCE_DIR}" "${
 file(GLOB RIVE_CPP_SOURCE_DIR_SUBDIRS LIST_DIRECTORIES true "${RIVE_CPP_SOURCE_DIR}/*")
 list(GET RIVE_CPP_SOURCE_DIR_SUBDIRS 0 RIVE_CPP_SOURCE_DIR)
 
-set(HARFBUZZ_DOWNLOAD_URL "https://codeload.github.com/harfbuzz/harfbuzz/zip/858570b1d9912a1b746ab39fbe62a646c4f7a5b1")
+set(HARFBUZZ_DOWNLOAD_URL "https://github.com/harfbuzz/harfbuzz/archive/refs/tags/8.2.2.zip")
 set(HARFBUZZ_DOWNLOAD_DIR "${CMAKE_BINARY_DIR}/harfbuzz-src-download")
 set(HARFBUZZ_SOURCE_DIR "${RIVE_CPP_SOURCE_DIR}/harfbuzz/")
 set(HARFBUZZ_CPP_TARGET_DIR "zip")
@@ -78,7 +78,7 @@ set(HARFBUZZ_CPP_TARGET_DIR "zip")
 file(DOWNLOAD ${HARFBUZZ_DOWNLOAD_URL} "${HARFBUZZ_DOWNLOAD_DIR}/harfbuzz.zip" SHOW_PROGRESS)
 extract_zip("${HARFBUZZ_DOWNLOAD_DIR}/harfbuzz.zip" "${HARFBUZZ_SOURCE_DIR}" "${HARFBUZZ_CPP_TARGET_DIR}")
 
-set(SHEENBIDI_DOWNLOAD_URL "https://codeload.github.com/Tehreer/SheenBidi/zip/refs/tags/v2.6")
+set(SHEENBIDI_DOWNLOAD_URL "https://github.com/Tehreer/SheenBidi/archive/refs/tags/v2.6.zip")
 set(SHEENBIDI_DOWNLOAD_DIR "${CMAKE_BINARY_DIR}/sheenbidi-src-download")
 set(SHEENBIDI_SOURCE_DIR "${RIVE_CPP_SOURCE_DIR}/sheenbidi")
 set(SHEENBIDI_CPP_TARGET_DIR "zip")

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -110,5 +110,6 @@ copy %ROOT%\build\binary\examples\RiveQtQuickPlugin\RiveQtQuickSimpleViewer.exe 
 CALL %SDKS_LOCATION%\Qt6\bin\windeployqt.exe %ROOT%\deploy\RiveQtQuickSimpleViewer.exe --no-translations
 
 ```
+And copy `RiveQtQuickPlugin.dll` to deploy directory from `build\binary\RiveQtQuickPlugin\RiveQtQuickPlugin.dll`
 
 Please read the [README.md](https://github.com/madoodia/RiveQtQuickPlugin/blob/main/README.md) file.

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,0 +1,114 @@
+# **Build Configuration**
+
+---
+
+## **Windows**
+
+### **Building**
+
+You can create your own batch files like `build.bat` file in the root of the project with these codes:
+
+```bat
+@REM SPDX-FileCopyrightText: 2023 Jeremias Bosch <jeremias.bosch@basyskom.com>
+@REM SPDX-FileCopyrightText: 2023 Jonas Kalinka <jonas.kalinka@basyskom.com>
+@REM SPDX-FileCopyrightText: 2023 basysKom GmbH
+@REM SPDX-FileCopyrightText: 2023 Reza Aarabi <madoodia@gmail.com>
+
+@REM SPDX-License-Identifier: LGPL-3.0-or-later
+@REM --------------------------------------------------------------------------
+
+@REM Getting the Root Directory When this file will be run
+set ROOT=%~dp0
+
+
+@REM VCVARS_LOCATION: C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build
+@REM If you have installed other versions of Visual Studio Build Tools like 2019 you can set its path to this Environment Variable
+echo  %VCVARS_LOCATION%
+
+@REM Setting vcvars_ver flag is important
+@REM Visual Studio 2019 Compiler
+@REM call "%VCVARS_LOCATION%/vcvarsall.bat" x64 -vcvars_ver=14.29.30133
+
+@REM Visual Studio 2022 Compiler
+call "%VCVARS_LOCATION%/vcvarsall.bat" x64 -vcvars_ver=14.36.32532
+
+
+
+cd %ROOT%
+
+if not exist "build" (
+    mkdir "build"
+)
+
+
+@REM REM Qt5_DIR
+@REM set Qt5_DIR=%SDKS_LOCATION%/Qt5/lib/cmake
+@REM set PATH=%PATH%;%SDKS_LOCATION%/Qt5/bin
+
+REM Qt6_DIR
+set Qt6_DIR=%SDKS_LOCATION%/Qt6/lib/cmake
+set PATH=%PATH%;%SDKS_LOCATION%/Qt6/bin
+
+cd "%ROOT%/build"
+
+@REM cmake -G "Visual Studio 16 2019" -A x64 -DCMAKE_PREFIX_PATH=%Qt6_DIR%  -DCMAKE_CXX_FLAGS="/bigobj" "%ROOT%"
+cmake -G "NMake Makefiles" -DCMAKE_PREFIX_PATH=%Qt6_DIR%  -DCMAKE_CXX_FLAGS="/bigobj" "%ROOT%"
+@REM cmake --build . --config Debug
+cmake --build . --config Release
+
+```
+
+### **Running**
+
+You can create your own batch files like `run.bat` file in the root of the project with these codes:
+
+```bat
+@REM SPDX-FileCopyrightText: 2023 Jeremias Bosch <jeremias.bosch@basyskom.com>
+@REM SPDX-FileCopyrightText: 2023 Jonas Kalinka <jonas.kalinka@basyskom.com>
+@REM SPDX-FileCopyrightText: 2023 basysKom GmbH
+@REM SPDX-FileCopyrightText: 2023 Reza Aarabi <madoodia@gmail.com>
+
+@REM SPDX-License-Identifier: LGPL-3.0-or-later
+@REM --------------------------------------------------------------------------
+
+@REM Getting the Root Directory When this file will be run
+set ROOT=%~dp0
+
+@REM set PATH=%PATH%;%SDKS_LOCATION%/Qt5/bin
+set PATH=%PATH%;%SDKS_LOCATION%/Qt6/bin
+
+set QML2_IMPORT_PATH=%ROOT%\build\binary
+
+CALL %ROOT%\build\binary\examples\RiveQtQuickPlugin\RiveQtQuickSimpleViewer.exe
+
+```
+
+### **Deployment**
+
+If you want to make a package of the tool and ship it, you can create your own `deploy.bat` file in the root of the project with these codes:
+
+```bat
+@REM SPDX-FileCopyrightText: 2023 Jeremias Bosch <jeremias.bosch@basyskom.com>
+@REM SPDX-FileCopyrightText: 2023 Jonas Kalinka <jonas.kalinka@basyskom.com>
+@REM SPDX-FileCopyrightText: 2023 basysKom GmbH
+@REM SPDX-FileCopyrightText: 2023 Reza Aarabi <madoodia@gmail.com>
+
+@REM SPDX-License-Identifier: LGPL-3.0-or-later
+@REM --------------------------------------------------------------------------
+
+@REM Getting the Root Directory When this file will be run
+set ROOT=%~dp0
+
+cd %ROOT%
+if not exist "deploy" (
+    mkdir "deploy"
+)
+
+
+copy %ROOT%\build\binary\examples\RiveQtQuickPlugin\RiveQtQuickSimpleViewer.exe "%ROOT%\deploy"
+
+CALL %SDKS_LOCATION%\Qt6\bin\windeployqt.exe %ROOT%\deploy\RiveQtQuickSimpleViewer.exe --no-translations
+
+```
+
+Please read the [README.md](https://github.com/madoodia/RiveQtQuickPlugin/blob/main/README.md) file.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,10 @@ if(NOT WIN32)
     add_compile_options(-gdwarf-4)
 endif()
 
+
+# setting /MD for the project
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
+
 # Add rive-cpp dependency if required
 if(${RQQRP_DOWNLOAD_BUILD_DEPENDENCIES})
     add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/3rdParty/rive/cmake)

--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ cmake -DCMAKE_PREFIX_PATH=~/.Qt/6.5.1/gcc_64 -S .. -B .
 make
 ```
 
+For more info on take a look at [BUILDING.md](https://github.com/madoodia/RiveQtQuickPlugin/blob/main/BUILDING.md).
+
+
 ## Usage
 
 Here's a short example of how to use the RiveQtQuickItem in your QML code:

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ cmake -DCMAKE_PREFIX_PATH=~/.Qt/6.5.1/gcc_64 -S .. -B .
 make
 ```
 
-For more info on take a look at [BUILDING.md](https://github.com/madoodia/RiveQtQuickPlugin/blob/main/BUILDING.md).
+For more info, take a look at [BUILDING.md](https://github.com/madoodia/RiveQtQuickPlugin/blob/main/BUILDING.md).
 
 
 ## Usage


### PR DESCRIPTION
Hello Developer Colleagues

This is a PR for my experimental building the whole package on Windows10, I hope it goes you well,.

This will help people who want to build the package in Windows with cl.exe as the compiler.

I've created a **BUILDING.md** file and explained what they need to do.

During the build process I've encountered a bunch of errors that tried to fix them, for example using `/bigobj` flag in the compiler for HarfBuzz package. that is added to the cmake builder.

and I should say I've build the application against:
- Qt5 - VS2019 - Release/Debug
- Qt5 - VS2022 - Release/Debug
- Qt6 - VS2019 - Release/Debug
- Qt6 - VS2022 - Release/Debug
all worked and could run the executable file, but in Qt6 I got some warning or Failed message (not Fatal) during build process, like these :

```c
...
spirv-opt -O C:\Users\Chapool\AppData\Local\Temp\qsb-ZnQRKR\qsb_spv_temp -o C:\Users\Chapool\AppData\Local\Temp\qsb-ZnQRKR\qsb_spv_temp_out
Failed to run spirv-opt -O C:\Users\Chapool\AppData\Local\Temp\qsb-ZnQRKR\qsb_spv_temp -o C:\Users\Chapool\AppData\Local\Temp\qsb-ZnQRKR\qsb_spv_temp_out: Process failed to start: The system cannot find the file specified.
fxc /nologo /E main /T ps_5_0 /Fo C:\Users\Chapool\AppData\Local\Temp\qsb-Fhslhc\qsb_hlsl_temp_out C:\Users\Chapool\AppData\Local\Temp\qsb-Fhslhc\qsb_hlsl_temp
[ 87%] Generating .qsb/shaders/qt6/blendRiveTextureNode.vert.qsb
spirv-opt -O C:\Users\Chapool\AppData\Local\Temp\qsb-ogCHaB\qsb_spv_temp -o C:\Users\Chapool\AppData\Local\Temp\qsb-ogCHaB\qsb_spv_temp_out
Failed to run spirv-opt -O C:\Users\Chapool\AppData\Local\Temp\qsb-ogCHaB\qsb_spv_temp -o C:\Users\Chapool\AppData\Local\Temp\qsb-ogCHaB\qsb_spv_temp_out: Process failed to start: The system cannot find the file specified.
spirv-opt -O C:\Users\Chapool\AppData\Local\Temp\qsb-ogCHaB\qsb_spv_temp -o C:\Users\Chapool\AppData\Local\Temp\qsb-ogCHaB\qsb_spv_temp_out
Failed to run spirv-opt -O C:\Users\Chapool\AppData\Local\Temp\qsb-ogCHaB\qsb_spv_temp -o C:\Users\Chapool\AppData\Local\Temp\qsb-ogCHaB\qsb_spv_temp_out: Process failed to start: The system cannot find the file specified.
fxc /nologo /E main /T vs_5_0 /Fo C:\Users\Chapool\AppData\Local\Temp\qsb-VVogop\qsb_hlsl_temp_out C:\Users\Chapool\AppData\Local\Temp\qsb-VVogop\qsb_hlsl_temp
fxc /nologo /E main /T vs_5_0 /Fo C:\Users\Chapool\AppData\Local\Temp\qsb-VVogop\qsb_hlsl_temp_out C:\Users\Chapool\AppData\Local\Temp\qsb-VVogop\qsb_hlsl_temp
...
```

And the result is a little bit weird that I showed in the picture.

![image](https://github.com/basysKom/RiveQtQuickPlugin/assets/3639157/feedf7e0-daba-43ea-bc1a-10839158da83)

btw, I liked the way you build the rive-cpp, really I did!

thanks