### PR TITLE
Fix "Framebuffer incomplete" errors when using the OpenGL RHI backend

### DIFF
--- a/examples/SimpleViewer/RiveInspectorView.qml
+++ b/examples/SimpleViewer/RiveInspectorView.qml
@@ -154,7 +154,7 @@ Item {
                     currentStateMachineIndex: -1
 
                     renderQuality: RiveQtQuickItem.Medium
-                    postprocessingMode: RiveQtQuickItem.SMAA
+                    postprocessingMode: RiveQtQuickItem.None
                     fillMode: RiveQtQuickItem.PreserveAspectFit
 
                     onStateMachineStringInterfaceChanged: {

--- a/examples/SimpleViewer/main.cpp
+++ b/examples/SimpleViewer/main.cpp
@@ -12,9 +12,13 @@
 int main(int argc, char *argv[])
 {
 
+    QSurfaceFormat f;
+    f.setSamples(4);
+    QSurfaceFormat::setDefaultFormat(f);
+
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     // Force OpenGL
-   // QQuickWindow::setGraphicsApi(QSGRendererInterface::OpenGLRhi);
+    QQuickWindow::setGraphicsApi(QSGRendererInterface::OpenGL);
 #endif
 
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)

--- a/examples/SimpleViewer/main.cpp
+++ b/examples/SimpleViewer/main.cpp
@@ -18,7 +18,7 @@ int main(int argc, char *argv[])
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     // Force OpenGL
-    QQuickWindow::setGraphicsApi(QSGRendererInterface::OpenGL);
+    // QQuickWindow::setGraphicsApi(QSGRendererInterface::OpenGL);
 #endif
 
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)

--- a/src/RiveQtQuickItem/CMakeLists.txt
+++ b/src/RiveQtQuickItem/CMakeLists.txt
@@ -108,7 +108,6 @@ include_directories(${Qt${QT_VERSION_MAJOR}Gui_PRIVATE_INCLUDE_DIRS})
 if (${QT_VERSION_MAJOR} EQUAL 6)
     find_package(Qt6 COMPONENTS ShaderTools)
     qt6_add_shaders(${PROJECT_NAME} "graph-shaders"
-        GLSL "300es,330"
         BATCHABLE
         PRECOMPILE
         OPTIMIZED

--- a/src/RiveQtQuickItem/renderer/riveqtfactory.cpp
+++ b/src/RiveQtQuickItem/renderer/riveqtfactory.cpp
@@ -28,18 +28,15 @@ RiveQSGRenderNode *RiveQtFactory::renderNode(QQuickWindow *window, std::weak_ptr
     case QSGRendererInterface::GraphicsApi::Direct3D11Rhi: {
         QSGRendererInterface *renderInterface = window->rendererInterface();
         QRhi *rhi = static_cast<QRhi *>(renderInterface->getResource(window, QSGRendererInterface::RhiResource));
+        if (rhi->isFeatureSupported(QRhi::MultisampleTexture) && rhi->isFeatureSupported(QRhi::MultisampleRenderBuffer)) {
 
-        auto sampleCounts = rhi->supportedSampleCounts();
-
-        if (rhi->isFeatureSupported(QRhi::MultisampleTexture) && rhi->isFeatureSupported(QRhi::MultisampleRenderBuffer)
-            && sampleCounts.contains(RiveQSGRenderNode::MULTISAMPLE_COUNT)) {
             auto node = new RiveQSGRHIRenderNode(window, artboardInstance, geometry);
             node->setFillMode(m_renderSettings.fillMode);
             node->setPostprocessingMode(m_renderSettings.postprocessingMode);
             return node;
         } else {
             qCritical(rqqpFactory)
-                << "RiveQtQuickPlign requires 4x multisample support. The hardware does not support 4x multisampling. Switch to "
+                << "RiveQtQuickPlign requires multisample support. The hardware does not support multisampling. Switch to "
                    "SoftwareRenderer.";
             return nullptr;
         }

--- a/src/RiveQtQuickItem/renderer/riveqtfactory.cpp
+++ b/src/RiveQtQuickItem/renderer/riveqtfactory.cpp
@@ -48,21 +48,6 @@ RiveQSGRenderNode *RiveQtFactory::renderNode(QQuickWindow *window, std::weak_ptr
     }
 }
 
-rive::rcp<rive::RenderBuffer> RiveQtFactory::makeBufferU16(rive::Span<const uint16_t> data)
-{
-    return nullptr;
-}
-
-rive::rcp<rive::RenderBuffer> RiveQtFactory::makeBufferU32(rive::Span<const uint32_t> data)
-{
-    return nullptr;
-}
-
-rive::rcp<rive::RenderBuffer> RiveQtFactory::makeBufferF32(rive::Span<const float> data)
-{
-    return nullptr;
-}
-
 rive::rcp<rive::RenderBuffer> RiveQtFactory::makeRenderBuffer(rive::RenderBufferType renderBufferType, rive::RenderBufferFlags renderBufferFlags, size_t size)
 {
     return rive::make_rcp<rive::DataRenderBuffer>(renderBufferType, renderBufferFlags, size);;

--- a/src/RiveQtQuickItem/renderer/riveqtfactory.cpp
+++ b/src/RiveQtQuickItem/renderer/riveqtfactory.cpp
@@ -28,16 +28,20 @@ RiveQSGRenderNode *RiveQtFactory::renderNode(QQuickWindow *window, std::weak_ptr
     case QSGRendererInterface::GraphicsApi::Direct3D11Rhi: {
         QSGRendererInterface *renderInterface = window->rendererInterface();
         QRhi *rhi = static_cast<QRhi *>(renderInterface->getResource(window, QSGRendererInterface::RhiResource));
-        if (rhi->isFeatureSupported(QRhi::MultisampleTexture) && rhi->isFeatureSupported(QRhi::MultisampleRenderBuffer)) {
 
+        auto sampleCounts = rhi->supportedSampleCounts();
+        auto requestedSamplesFromFormat = window->format().samples();
+
+        if (requestedSamplesFromFormat == 1 || (requestedSamplesFromFormat > 1 
+            && rhi->isFeatureSupported(QRhi::MultisampleRenderBuffer)
+            && sampleCounts.contains(requestedSamplesFromFormat))) {
             auto node = new RiveQSGRHIRenderNode(window, artboardInstance, geometry);
             node->setFillMode(m_renderSettings.fillMode);
             node->setPostprocessingMode(m_renderSettings.postprocessingMode);
             return node;
         } else {
             qCritical(rqqpFactory)
-                << "RiveQtQuickPlign requires multisample support. The hardware does not support multisampling. Switch to "
-                   "SoftwareRenderer.";
+                << "MSAA requested, but requested sample size is not supported - requested sample size:" << requestedSamplesFromFormat;
             return nullptr;
         }
     }

--- a/src/RiveQtQuickItem/renderer/riveqtfactory.cpp
+++ b/src/RiveQtQuickItem/renderer/riveqtfactory.cpp
@@ -48,10 +48,24 @@ RiveQSGRenderNode *RiveQtFactory::renderNode(QQuickWindow *window, std::weak_ptr
     }
 }
 
-rive::rcp<rive::RenderBuffer> RiveQtFactory::makeRenderBuffer(rive::RenderBufferType renderBufferType,
-                                                              rive::RenderBufferFlags renderBufferFlags, size_t size)
+rive::rcp<rive::RenderBuffer> RiveQtFactory::makeBufferU16(rive::Span<const uint16_t> data)
 {
-    return rive::make_rcp<rive::DataRenderBuffer>(renderBufferType, renderBufferFlags, size);
+    return nullptr;
+}
+
+rive::rcp<rive::RenderBuffer> RiveQtFactory::makeBufferU32(rive::Span<const uint32_t> data)
+{
+    return nullptr;
+}
+
+rive::rcp<rive::RenderBuffer> RiveQtFactory::makeBufferF32(rive::Span<const float> data)
+{
+    return nullptr;
+}
+
+rive::rcp<rive::RenderBuffer> RiveQtFactory::makeRenderBuffer(rive::RenderBufferType renderBufferType, rive::RenderBufferFlags renderBufferFlags, size_t size)
+{
+    return rive::make_rcp<rive::DataRenderBuffer>(renderBufferType, renderBufferFlags, size);;
 }
 
 rive::rcp<rive::RenderShader> RiveQtFactory::makeLinearGradient(float x1, float y1, float x2, float y2, const rive::ColorInt *colors,
@@ -146,6 +160,7 @@ rive::rcp<rive::Font> RiveQtFactory::decodeFont(rive::Span<const uint8_t> span)
 
     QFont font(fontFamilies.first());
     return rive::rcp<RiveQtFont>(new RiveQtFont(font));*/
+
 }
 
 unsigned int RiveQtFactory::levelOfDetail()

--- a/src/RiveQtQuickItem/renderer/riveqtfactory.h
+++ b/src/RiveQtQuickItem/renderer/riveqtfactory.h
@@ -43,11 +43,6 @@ public:
     void setRenderSettings(const RiveRenderSettings &renderSettings) { m_renderSettings = renderSettings; }
 
     RiveQSGRenderNode *renderNode(QQuickWindow *window, std::weak_ptr<rive::ArtboardInstance> artboardInstance, const QRectF &geometry);
-
-    rive::rcp<rive::RenderBuffer> makeBufferU16(rive::Span<const uint16_t> data);
-    rive::rcp<rive::RenderBuffer> makeBufferU32(rive::Span<const uint32_t> data);
-    rive::rcp<rive::RenderBuffer> makeBufferF32(rive::Span<const float> data);
-
     rive::rcp<rive::RenderBuffer> makeRenderBuffer(rive::RenderBufferType, rive::RenderBufferFlags, size_t) override;
 
     rive::rcp<rive::RenderShader> makeLinearGradient(float, float, float, float, const rive::ColorInt[], const float[], size_t) override;

--- a/src/RiveQtQuickItem/renderer/riveqtfactory.h
+++ b/src/RiveQtQuickItem/renderer/riveqtfactory.h
@@ -16,7 +16,7 @@
 #include <utils/factory_utils.hpp>
 
 #ifdef WITH_RIVE_TEXT
-#    include <rive/text/font_hb.hpp>
+#include <rive/text/font_hb.hpp>
 #endif
 
 #include "datatypes.h"
@@ -43,6 +43,10 @@ public:
     void setRenderSettings(const RiveRenderSettings &renderSettings) { m_renderSettings = renderSettings; }
 
     RiveQSGRenderNode *renderNode(QQuickWindow *window, std::weak_ptr<rive::ArtboardInstance> artboardInstance, const QRectF &geometry);
+
+    rive::rcp<rive::RenderBuffer> makeBufferU16(rive::Span<const uint16_t> data);
+    rive::rcp<rive::RenderBuffer> makeBufferU32(rive::Span<const uint32_t> data);
+    rive::rcp<rive::RenderBuffer> makeBufferF32(rive::Span<const float> data);
 
     rive::rcp<rive::RenderBuffer> makeRenderBuffer(rive::RenderBufferType, rive::RenderBufferFlags, size_t) override;
 

--- a/src/RiveQtQuickItem/renderer/riveqtrhirenderer.cpp
+++ b/src/RiveQtQuickItem/renderer/riveqtrhirenderer.cpp
@@ -97,27 +97,29 @@ void RiveQtRhiRenderer::drawPath(rive::RenderPath *path, rive::RenderPaint *pain
     }
 
     RiveQtPath clipResult;
-    QPair<QPainterPath, QMatrix4x4> firstLevel = m_rhiRenderStack.back().m_allClipPainterPathesApplied.first();
+    if (!m_rhiRenderStack.back().m_allClipPainterPathesApplied.empty()) {
+        QPair<QPainterPath, QMatrix4x4> firstLevel = m_rhiRenderStack.back().m_allClipPainterPathesApplied.first();
 
-    clipResult.setQPainterPath(firstLevel.first);
-    clipResult.applyMatrix(firstLevel.second);
+        clipResult.setQPainterPath(firstLevel.first);
+        clipResult.applyMatrix(firstLevel.second);
 
-    for (int i = 1; i < m_rhiRenderStack.back().m_allClipPainterPathesApplied.count(); ++i) {
-        RiveQtPath a;
-        const auto &entry = m_rhiRenderStack.back().m_allClipPainterPathesApplied[i];
-        a.setQPainterPath(entry.first);
-        a.applyMatrix(entry.second);
-        clipResult.intersectWith(a.toQPainterPath());
+        for (int i = 1; i < m_rhiRenderStack.back().m_allClipPainterPathesApplied.count(); ++i) {
+            RiveQtPath a;
+            const auto &entry = m_rhiRenderStack.back().m_allClipPainterPathesApplied[i];
+            a.setQPainterPath(entry.first);
+            a.applyMatrix(entry.second);
+            clipResult.intersectWith(a.toQPainterPath());
+        }
+
+        // #if 0 // this allows to draw the clipping area which it useful for debugging :)
+        //    TextureTargetNode *drawClipping = getRiveDrawTargetNode();
+        //    drawClipping->setOpacity(currentOpacity()); // inherit the opacity from the parent
+        //    drawClipping->setColor(QColor(255, 0, 0, 29));
+        //    drawClipping->updateGeometry(clipResult.toVertices(), QMatrix4x4());
+        //  #endif
+
+        node->updateClippingGeometry(clipResult.toVertices());
     }
-
-    // #if 0 // this allows to draw the clipping area which it useful for debugging :)
-    //    TextureTargetNode *drawClipping = getRiveDrawTargetNode();
-    //    drawClipping->setOpacity(currentOpacity()); // inherit the opacity from the parent
-    //    drawClipping->setColor(QColor(255, 0, 0, 29));
-    //    drawClipping->updateGeometry(clipResult.toVertices(), QMatrix4x4());
-    //  #endif
-
-    node->updateClippingGeometry(clipResult.toVertices());
 
     node->updateGeometry(pathData, transformMatrix());
 }

--- a/src/RiveQtQuickItem/renderer/riveqtrhirenderer.cpp
+++ b/src/RiveQtQuickItem/renderer/riveqtrhirenderer.cpp
@@ -97,29 +97,27 @@ void RiveQtRhiRenderer::drawPath(rive::RenderPath *path, rive::RenderPaint *pain
     }
 
     RiveQtPath clipResult;
-    if (!m_rhiRenderStack.back().m_allClipPainterPathesApplied.empty()) {
-        QPair<QPainterPath, QMatrix4x4> firstLevel = m_rhiRenderStack.back().m_allClipPainterPathesApplied.first();
+    QPair<QPainterPath, QMatrix4x4> firstLevel = m_rhiRenderStack.back().m_allClipPainterPathesApplied.first();
 
-        clipResult.setQPainterPath(firstLevel.first);
-        clipResult.applyMatrix(firstLevel.second);
+    clipResult.setQPainterPath(firstLevel.first);
+    clipResult.applyMatrix(firstLevel.second);
 
-        for (int i = 1; i < m_rhiRenderStack.back().m_allClipPainterPathesApplied.count(); ++i) {
-            RiveQtPath a;
-            const auto &entry = m_rhiRenderStack.back().m_allClipPainterPathesApplied[i];
-            a.setQPainterPath(entry.first);
-            a.applyMatrix(entry.second);
-            clipResult.intersectWith(a.toQPainterPath());
-        }
-
-        // #if 0 // this allows to draw the clipping area which it useful for debugging :)
-        //    TextureTargetNode *drawClipping = getRiveDrawTargetNode();
-        //    drawClipping->setOpacity(currentOpacity()); // inherit the opacity from the parent
-        //    drawClipping->setColor(QColor(255, 0, 0, 29));
-        //    drawClipping->updateGeometry(clipResult.toVertices(), QMatrix4x4());
-        //  #endif
-
-        node->updateClippingGeometry(clipResult.toVertices());
+    for (int i = 1; i < m_rhiRenderStack.back().m_allClipPainterPathesApplied.count(); ++i) {
+        RiveQtPath a;
+        const auto &entry = m_rhiRenderStack.back().m_allClipPainterPathesApplied[i];
+        a.setQPainterPath(entry.first);
+        a.applyMatrix(entry.second);
+        clipResult.intersectWith(a.toQPainterPath());
     }
+
+    // #if 0 // this allows to draw the clipping area which it useful for debugging :)
+    //    TextureTargetNode *drawClipping = getRiveDrawTargetNode();
+    //    drawClipping->setOpacity(currentOpacity()); // inherit the opacity from the parent
+    //    drawClipping->setColor(QColor(255, 0, 0, 29));
+    //    drawClipping->updateGeometry(clipResult.toVertices(), QMatrix4x4());
+    //  #endif
+
+    node->updateClippingGeometry(clipResult.toVertices());
 
     node->updateGeometry(pathData, transformMatrix());
 }

--- a/src/RiveQtQuickItem/rhi/postprocessingsmaa.h
+++ b/src/RiveQtQuickItem/rhi/postprocessingsmaa.h
@@ -23,8 +23,8 @@ public:
     bool isInitialized() const { return m_isInitialized; }
 
     // void initializePostprocessingPipeline(QRhi *rhi, const QSizeF &size, std::weak_ptr<QRhiTexture> frameTexture);
-    void initializePostprocessingPipeline(QRhi *rhi, QRhiCommandBuffer *commandBuffer, int samples, const QSize &size,
-                                          QRhiTexture *frameTextureA, QRhiTexture *frameTextureB);
+    void initializePostprocessingPipeline(QRhi *rhi, QRhiCommandBuffer *commandBuffer, const QSize &size, QRhiTexture *frameTextureA,
+                                          QRhiTexture *frameTextureB);
     void postprocess(QRhi *rhi, QRhiCommandBuffer *commandBuffer, bool useTextureBufferA);
     void cleanup();
 
@@ -105,6 +105,4 @@ private:
     QRhiTexture *m_postprocessingRenderTexture { nullptr };
 
     QSGRendererInterface::GraphicsApi m_api;
-
-    int m_samples { 4 };
 };

--- a/src/RiveQtQuickItem/rhi/texturetargetnode.cpp
+++ b/src/RiveQtQuickItem/rhi/texturetargetnode.cpp
@@ -453,11 +453,9 @@ void TextureTargetNode::renderBlend(QRhiCommandBuffer *cb)
     QMatrix4x4 mvp = (*m_projectionMatrix);
     mvp.translate(-m_rect.x(), -m_rect.y());
     int flipped = rhi->isYUpInFramebuffer() ? 1 : 0;
-    int sampleCount = m_node->currentBlendTarget()->sampleCount();
     m_blendResourceUpdates->updateDynamicBuffer(m_blendUniformBuffer, 0, 64, mvp.constData());
     m_blendResourceUpdates->updateDynamicBuffer(m_blendUniformBuffer, 64, 4, &m_blendMode);
     m_blendResourceUpdates->updateDynamicBuffer(m_blendUniformBuffer, 68, 4, &flipped);
-    m_blendResourceUpdates->updateDynamicBuffer(m_blendUniformBuffer, 72, 4, &sampleCount);
 
     auto *currentDisplayBufferTarget = m_node->currentBlendTarget();
     auto *blendPipeline = m_node->currentBlendPipeline();
@@ -530,10 +528,15 @@ void TextureTargetNode::setGradient(const QGradient *gradient)
     }
 }
 
-void TextureTargetNode::setTexture(const QImage &image, rive::rcp<rive::RenderBuffer> vertices, rive::rcp<rive::RenderBuffer> uvCoords,
-                                   rive::rcp<rive::RenderBuffer> indices, uint32_t vertexCount, uint32_t indexCount, bool recreate,
-                                   const QMatrix4x4 &transform)
+void TextureTargetNode::setTexture(const QImage &image,
+                    rive::rcp<rive::RenderBuffer> vertices,
+                    rive::rcp<rive::RenderBuffer> uvCoords,
+                    rive::rcp<rive::RenderBuffer> indices,
+                    uint32_t vertexCount, uint32_t indexCount,
+                    bool recreate,
+                    const QMatrix4x4 &transform)
 {
+    
     if (m_texture.size() != image.size()) {
         if (m_sampler) {
             m_cleanupList.removeAll(m_sampler);
@@ -641,8 +644,8 @@ void TextureTargetNode::setTexture(const QImage &image, rive::rcp<rive::RenderBu
         assert(indices->sizeInBytes() == indexCount * sizeof(uint16_t));
 
         auto *vertexData = rive::DataRenderBuffer::Cast(vertices.get())->f32s();
-        auto *uvData = rive::DataRenderBuffer::Cast(uvCoords.get())->f32s();
-        auto *indexData = rive::DataRenderBuffer::Cast(indices.get())->u16s();
+        auto *uvData     = rive::DataRenderBuffer::Cast(uvCoords.get())->f32s();
+        auto *indexData  = rive::DataRenderBuffer::Cast(indices.get())->u16s();
 
         m_geometryData.resize(vertices->sizeInBytes());
         memcpy(m_geometryData.data(), vertexData, vertices->sizeInBytes());

--- a/src/RiveQtQuickItem/riveqsgrendernode.cpp
+++ b/src/RiveQtQuickItem/riveqsgrendernode.cpp
@@ -6,8 +6,6 @@
 #include "riveqsgrendernode.h"
 #include "riveqtquickitem.h"
 
-const int RiveQSGBaseNode::MULTISAMPLE_COUNT = 4;
-
 QRectF RiveQSGRenderNode::rect() const
 {
     return m_rect;

--- a/src/RiveQtQuickItem/riveqsgrendernode.h
+++ b/src/RiveQtQuickItem/riveqsgrendernode.h
@@ -28,8 +28,6 @@ public:
 
     virtual void setArtboardRect(const QRectF &bounds);
 
-    static const int MULTISAMPLE_COUNT { 4 };
-
 protected:
     std::weak_ptr<rive::ArtboardInstance> m_artboardInstance;
     QRectF m_rect;

--- a/src/RiveQtQuickItem/riveqsgrendernode.h
+++ b/src/RiveQtQuickItem/riveqsgrendernode.h
@@ -28,7 +28,7 @@ public:
 
     virtual void setArtboardRect(const QRectF &bounds);
 
-    static const int MULTISAMPLE_COUNT;
+    static const int MULTISAMPLE_COUNT { 4 };
 
 protected:
     std::weak_ptr<rive::ArtboardInstance> m_artboardInstance;

--- a/src/RiveQtQuickItem/riveqsgrhirendernode.h
+++ b/src/RiveQtQuickItem/riveqsgrhirendernode.h
@@ -159,11 +159,10 @@ protected:
 
     PostprocessingSMAA *m_postprocessing { nullptr };
 
+
 private:
-    void resetResources();
-
     float m_pixelRatio { 1.0f };
-
+    int m_samples { 4 };
     QRhiGraphicsPipeline *createBlendPipeline(QRhi *rhi, QRhiRenderPassDescriptor *renderPass, QRhiShaderResourceBindings *bindings);
     QRhiGraphicsPipeline *createClipPipeline(QRhi *rhi, QRhiRenderPassDescriptor *renderPassDescriptor,
                                              QRhiShaderResourceBindings *bindings);

--- a/src/RiveQtQuickItem/riveqsgrhirendernode.h
+++ b/src/RiveQtQuickItem/riveqsgrhirendernode.h
@@ -68,6 +68,7 @@ public:
 protected:
     struct RenderSurface
     {
+        QRhiRenderBuffer *buffer { nullptr };
         QRhiTexture *texture { nullptr };
         QRhiRenderPassDescriptor *desc { nullptr };
         QRhiRenderPassDescriptor *blendDesc { nullptr };
@@ -81,7 +82,7 @@ protected:
         bool valid() { return texture != nullptr; }
 
         // this creates all resources needed to have a texture to draw on
-        bool create(QRhi *rhi, const QSize &surfaceSize, QRhiRenderBuffer *stencilClippingBuffer,
+        bool create(QRhi *rhi, int samples, const QSize &surfaceSize, QRhiRenderBuffer *stencilClippingBuffer,
                     QRhiTextureRenderTarget::Flags flags = QRhiTextureRenderTarget::PreserveColorContents);
     };
 
@@ -157,6 +158,8 @@ protected:
     RiveRenderSettings::FillMode m_fillMode;
 
     PostprocessingSMAA *m_postprocessing { nullptr };
+
+    int m_sampleCount { 1 };
 
 private:
     QRhiGraphicsPipeline *createBlendPipeline(QRhi *rhi, QRhiRenderPassDescriptor *renderPass, QRhiShaderResourceBindings *bindings);

--- a/src/RiveQtQuickItem/riveqsgrhirendernode.h
+++ b/src/RiveQtQuickItem/riveqsgrhirendernode.h
@@ -73,7 +73,6 @@ protected:
         QRhiRenderPassDescriptor *blendDesc { nullptr };
         QRhiTextureRenderTarget *target { nullptr };
         QRhiTextureRenderTarget *blendTarget { nullptr };
-        QRhiTexture *resolveTexture { nullptr };
 
         ~RenderSurface() { cleanUp(); }
 
@@ -82,7 +81,7 @@ protected:
         bool valid() { return texture != nullptr; }
 
         // this creates all resources needed to have a texture to draw on
-        bool create(QRhi *rhi, int samples, const QSize &surfaceSize, QRhiRenderBuffer *stencilClippingBuffer,
+        bool create(QRhi *rhi, const QSize &surfaceSize, QRhiRenderBuffer *stencilClippingBuffer,
                     QRhiTextureRenderTarget::Flags flags = QRhiTextureRenderTarget::PreserveColorContents);
     };
 
@@ -159,14 +158,11 @@ protected:
 
     PostprocessingSMAA *m_postprocessing { nullptr };
 
-
 private:
-    float m_pixelRatio { 1.0f };
-    int m_samples { 4 };
     QRhiGraphicsPipeline *createBlendPipeline(QRhi *rhi, QRhiRenderPassDescriptor *renderPass, QRhiShaderResourceBindings *bindings);
     QRhiGraphicsPipeline *createClipPipeline(QRhi *rhi, QRhiRenderPassDescriptor *renderPassDescriptor,
                                              QRhiShaderResourceBindings *bindings);
-    QRhiGraphicsPipeline *createDrawPipeline(QRhi *rhi, int samples, bool srcOverBlend, bool stencilBuffer,
+    QRhiGraphicsPipeline *createDrawPipeline(QRhi *rhi, bool srcOverBlend, bool stencilBuffer,
                                              QRhiRenderPassDescriptor *renderPassDescriptor, QRhiGraphicsPipeline::Topology t,
                                              const QList<QRhiShaderStage> &shader, QRhiShaderResourceBindings *bindings);
 };

--- a/src/RiveQtQuickItem/riveqtquickitem.cpp
+++ b/src/RiveQtQuickItem/riveqtquickitem.cpp
@@ -141,9 +141,7 @@ void RiveQtQuickItem::updateInternalArtboard()
     if (m_currentArtboardIndex == -1) {
         m_currentArtboardInstance = m_riveFile->artboardDefault();
     } else {
-        if (!m_currentArtboardInstance || m_riveFile->artboardAt(m_currentArtboardIndex).get() != m_currentArtboardInstance->artboard()) {
-            m_currentArtboardInstance = m_riveFile->artboardAt(m_currentArtboardIndex);
-        }
+        m_currentArtboardInstance = m_riveFile->artboardAt(m_currentArtboardIndex);
     }
 
     if (!m_currentArtboardInstance) {
@@ -195,13 +193,11 @@ QSGNode *RiveQtQuickItem::updatePaintNode(QSGNode *oldNode, UpdatePaintNodeData 
         // of course the calls to the stateMachineInterface wont do anything
 
         m_renderNode->updateArtboardInstance(std::weak_ptr<rive::ArtboardInstance>());
-        m_currentArtboardInstance.reset();
+
         // reset all
         m_riveFile = nullptr;
         m_scheduleArtboardChange = true;
         m_scheduleStateMachineChange = true;
-        m_currentArtboardIndex = -1;
-        m_initialArtboardIndex = -1;
 
         // now load the file from the main thread -> connected as Queued Connection to make sure its called in its owning thread
         emit loadFileAfterUnloading(m_fileSource);
@@ -487,6 +483,10 @@ void RiveQtQuickItem::loadRiveFile(const QString &source)
         m_loadingStatus = Error;
         emit loadingStatusChanged();
         return;
+    }
+
+    if (m_currentArtboardInstance) {
+        m_currentArtboardInstance.reset();
     }
 
     QByteArray fileData = file.readAll();

--- a/src/RiveQtQuickItem/riveqtquickitem.cpp
+++ b/src/RiveQtQuickItem/riveqtquickitem.cpp
@@ -140,8 +140,8 @@ void RiveQtQuickItem::updateInternalArtboard()
 
     if (m_currentArtboardIndex == -1) {
         m_currentArtboardInstance = m_riveFile->artboardDefault();
-    } else {
-        m_currentArtboardInstance = m_riveFile->artboardAt(m_currentArtboardIndex);
+    } else if (!m_currentArtboardInstance || m_riveFile->artboardAt(m_currentArtboardIndex).get() != m_currentArtboardInstance->artboard()) {
+            m_currentArtboardInstance = m_riveFile->artboardAt(m_currentArtboardIndex);
     }
 
     if (!m_currentArtboardInstance) {
@@ -193,11 +193,15 @@ QSGNode *RiveQtQuickItem::updatePaintNode(QSGNode *oldNode, UpdatePaintNodeData 
         // of course the calls to the stateMachineInterface wont do anything
 
         m_renderNode->updateArtboardInstance(std::weak_ptr<rive::ArtboardInstance>());
+        m_currentArtboardInstance.reset();
 
         // reset all
         m_riveFile = nullptr;
         m_scheduleArtboardChange = true;
         m_scheduleStateMachineChange = true;
+        m_currentArtboardIndex = -1;
+        m_initialArtboardIndex = -1;
+
 
         // now load the file from the main thread -> connected as Queued Connection to make sure its called in its owning thread
         emit loadFileAfterUnloading(m_fileSource);
@@ -483,10 +487,6 @@ void RiveQtQuickItem::loadRiveFile(const QString &source)
         m_loadingStatus = Error;
         emit loadingStatusChanged();
         return;
-    }
-
-    if (m_currentArtboardInstance) {
-        m_currentArtboardInstance.reset();
     }
 
     QByteArray fileData = file.readAll();

--- a/src/RiveQtQuickItem/shaders/qt6/blendRiveTextureNode.frag
+++ b/src/RiveQtQuickItem/shaders/qt6/blendRiveTextureNode.frag
@@ -13,11 +13,10 @@ layout(std140, binding = 0) uniform buf {
     mat4 qt_Matrix;
     int blendMode;
     int flipped;
-    int sampleCount;
 };
 
-layout(binding = 1) uniform sampler2DMS u_texture_src;
-layout(binding = 2) uniform sampler2DMS u_texture_dest;
+layout(binding = 1) uniform sampler2D u_texture_src;
+layout(binding = 2) uniform sampler2D u_texture_dest;
 
 vec4 blendColor(vec4 color, vec4 src, vec4 dst) {
     float blendColor = src.a * dst.a;
@@ -331,22 +330,10 @@ vec4 blend(vec4 srcColor, vec4 destColor, int blendMode) {
     return blendedColor;
 }
 
-vec4 textureColor(sampler2DMS tex, vec2 texCoord) {
-
-    ivec2 tc = ivec2(floor(vec2(textureSize(tex)) * texCoord));
-
-    vec4 c = vec4(0.0);
-    for (int i = 0; i < sampleCount; ++i) {
-        c += texelFetch(tex, tc, i);
-    }
-    c /= float(sampleCount);
-    return vec4(c.rgb * c.a, c.a);
-}
-
 void main()
 {
-    vec4 srcColor = textureColor(u_texture_src, texCoord);
-    vec4 destColor = textureColor(u_texture_dest, texCoord);
+    vec4 srcColor = texture(u_texture_src, texCoord);
+    vec4 destColor = texture(u_texture_dest, texCoord);
 
     vec4 finalColor = blend(srcColor, destColor, blendMode);
 

--- a/src/RiveQtQuickItem/shaders/qt6/drawRiveTextureNode.frag
+++ b/src/RiveQtQuickItem/shaders/qt6/drawRiveTextureNode.frag
@@ -45,6 +45,7 @@ vec4 getGradientColor( float gradientCoord) {
     return gradientColor;
 }
 
+
 void main()
 {
     if (useTexture == 1) {

--- a/src/RiveQtQuickItem/shaders/qt6/edges.vert
+++ b/src/RiveQtQuickItem/shaders/qt6/edges.vert
@@ -41,7 +41,6 @@ layout(location = 1) out vec4 vOffset[3];
 layout(std140, binding = 0) uniform buf {
     vec2 resolution;
     int flip;
-    int sampleCount;
 } ubuf;
 
 out gl_PerVertex { vec4 gl_Position; };
@@ -52,7 +51,7 @@ void main() {
   v_texcoord = vec2(texcoord.x, texcoord.y);
   if (ubuf.flip != 0)
     v_texcoord.y = 1.0 - v_texcoord.y;
-
+  
   vOffset[0] = mad(SMAA_RT_METRICS.xyxy, vec4(-1.0, 0.0, 0.0, -1.0), v_texcoord.xyxy);
   vOffset[1] = mad(SMAA_RT_METRICS.xyxy, vec4(1.0, 0.0, 0.0, 1.0), v_texcoord.xyxy);
   vOffset[2] = mad(SMAA_RT_METRICS.xyxy, vec4(-2.0, 0.0, 0.0, -2.0), v_texcoord.xyxy);

--- a/src/RiveQtQuickItem/shaders/qt6/finalDraw.frag
+++ b/src/RiveQtQuickItem/shaders/qt6/finalDraw.frag
@@ -18,29 +18,20 @@ layout(std140, binding = 0) uniform buf {
     float top;
     float bottom;
     int useTextureNumber;
-    int sampleCount;
 };
 
-layout(binding = 1) uniform sampler2DMS u_textureA;
-layout(binding = 2) uniform sampler2DMS u_textureB;
-layout(binding = 3) uniform sampler2DMS u_texturePP;
+layout(binding = 1) uniform sampler2D u_textureA;
+layout(binding = 2) uniform sampler2D u_textureB;
+layout(binding = 3) uniform sampler2D u_texturePP;
 
-vec4 drawTexture(sampler2DMS tex, vec2 texCoord) {
+vec4 drawTexture(sampler2D s_texture, vec2 texCoord) {
     if (texCoord.x >= left && texCoord.x <= right &&
         texCoord.y >= top && texCoord.y <= bottom) {
-        ivec2 tc = ivec2(floor(vec2(textureSize(tex)) * texCoord));
-
-        vec4 c = vec4(0.0);
-        for (int i = 0; i < sampleCount; ++i) {
-            c += texelFetch(tex, tc, i);
-        }
-        c /= float(sampleCount);
-        return vec4(c.rgb * c.a, c.a);
+        return texture(s_texture, texCoord);
     } else {
-        return vec4(0.0);  // Return a transparent color for pixels outside the viewport
+        return vec4(0.0, 0.0, 0.0, 0.0);  // Return a transparent color for pixels outside the viewport
     }
 }
-
 
 void main()
 {

--- a/src/RiveQtQuickItem/shaders/qt6/smaa-blend.vert
+++ b/src/RiveQtQuickItem/shaders/qt6/smaa-blend.vert
@@ -41,7 +41,6 @@ layout(location = 1) out vec4 vOffset;
 layout(std140, binding = 0) uniform buf {
     vec2 resolution;
     int flip;
-    int sampleCount;
 } ubuf;
 
 out gl_PerVertex { vec4 gl_Position; };

--- a/src/RiveQtQuickItem/shaders/qt6/smaa-weights.frag
+++ b/src/RiveQtQuickItem/shaders/qt6/smaa-weights.frag
@@ -51,7 +51,7 @@
 #define mad(a, b, c) (a * b + c)
 #define saturate(a) clamp(a, 0.0, 1.0)
 #define round(v) floor(v + 0.5)
-#define SMAASampleLevelZeroOffset(tex, coord, offset) textureColor(tex, coord + offset * SMAA_RT_METRICS.xy)
+#define SMAASampleLevelZeroOffset(tex, coord, offset) texture(tex, coord + offset * SMAA_RT_METRICS.xy)
 
 // Non-Configurable Defines
 #define SMAA_AREATEX_MAX_DISTANCE 16
@@ -80,23 +80,11 @@ layout(location = 0) out vec4 fragColor;
 layout(std140, binding = 0) uniform buf {
     vec2 resolution;
     int flip;
-    int sampleCount;
 } ubuf;
 
-layout(binding = 1) uniform sampler2DMS edgesTex;
-layout(binding = 2) uniform sampler2DMS areaTex;
-layout(binding = 3) uniform sampler2DMS searchTex;
-
-vec4 textureColor(sampler2DMS tex, vec2 texCoord) {
-    ivec2 tc = ivec2(floor(vec2(textureSize(tex)) * texCoord));
-
-    vec4 c = vec4(0.0);
-    for (int i = 0; i < ubuf.sampleCount; ++i) {
-        c += texelFetch(tex, tc, i);
-    }
-    c /= float(ubuf.sampleCount);
-    return vec4(c.rgb * c.a, c.a);
-}
+layout(binding = 1) uniform sampler2D edgesTex;
+layout(binding = 2) uniform sampler2D areaTex;
+layout(binding = 3) uniform sampler2D searchTex;
 
 // globals
 vec4 SMAA_RT_METRICS;
@@ -143,20 +131,20 @@ vec4 SMAADecodeDiagBilinearAccess(vec4 e) {
 /**
  * These functions allows to perform diagonal pattern searches.
  */
-vec2 SMAASearchDiag1(sampler2DMS edgesTex, vec2 texcoord, vec2 dir, out vec2 e) {
+vec2 SMAASearchDiag1(sampler2D edgesTex, vec2 texcoord, vec2 dir, out vec2 e) {
   vec4 coord = vec4(texcoord, -1.0, 1.0);
   vec3 t = vec3(SMAA_RT_METRICS.xy, 1.0);
 
   for (int i = 0; i < SMAA_MAX_SEARCH_STEPS; i++) {
     if (!(coord.z < float(SMAA_MAX_SEARCH_STEPS_DIAG - 1) && coord.w > 0.9)) break;
     coord.xyz = mad(t, vec3(dir, 1.0), coord.xyz);
-    e = textureColor(edgesTex, coord.xy).rg; // LinearSampler
+    e = texture(edgesTex, coord.xy).rg; // LinearSampler
     coord.w = dot(e, vec2(0.5, 0.5));
   }
   return coord.zw;
 }
 
-vec2 SMAASearchDiag2(sampler2DMS edgesTex, vec2 texcoord, vec2 dir, out vec2 e) {
+vec2 SMAASearchDiag2(sampler2D edgesTex, vec2 texcoord, vec2 dir, out vec2 e) {
   vec4 coord = vec4(texcoord, -1.0, 1.0);
   coord.x += 0.25 * SMAA_RT_METRICS.x; // See @SearchDiag2Optimization
   vec3 t = vec3(SMAA_RT_METRICS.xy, 1.0);
@@ -167,11 +155,11 @@ vec2 SMAASearchDiag2(sampler2DMS edgesTex, vec2 texcoord, vec2 dir, out vec2 e) 
 
     // @SearchDiag2Optimization
     // Fetch both edges at once using bilinear filtering:
-    e = textureColor(edgesTex, coord.xy).rg; // LinearSampler
+    e = texture(edgesTex, coord.xy).rg; // LinearSampler
     e = SMAADecodeDiagBilinearAccess(e);
 
     // Non-optimized version:
-    // e.g = textureColor(edgesTex, coord.xy).g; // LinearSampler
+    // e.g = texture(edgesTex, coord.xy).g; // LinearSampler
     // e.r = SMAASampleLevelZeroOffset(edgesTex, coord.xy, vec2(1, 0)).r;
 
     coord.w = dot(e, vec2(0.5, 0.5));
@@ -183,7 +171,7 @@ vec2 SMAASearchDiag2(sampler2DMS edgesTex, vec2 texcoord, vec2 dir, out vec2 e) 
  * Similar to SMAAArea, this calculates the area corresponding to a certain
  * diagonal distance and crossing edges 'e'.
  */
-vec2 SMAAAreaDiag(sampler2DMS areaTex, vec2 dist, vec2 e, float offset) {
+vec2 SMAAAreaDiag(sampler2D areaTex, vec2 dist, vec2 e, float offset) {
   vec2 texcoord = mad(vec2(SMAA_AREATEX_MAX_DISTANCE_DIAG, SMAA_AREATEX_MAX_DISTANCE_DIAG), e, dist);
 
   // We do a scale and bias for mapping to texel space:
@@ -196,13 +184,13 @@ vec2 SMAAAreaDiag(sampler2DMS areaTex, vec2 dist, vec2 e, float offset) {
   texcoord.y += SMAA_AREATEX_SUBTEX_SIZE * offset;
 
   // Do it!
-  return SMAA_AREATEX_SELECT(textureColor(areaTex, texcoord)); // LinearSampler
+  return SMAA_AREATEX_SELECT(texture(areaTex, texcoord)); // LinearSampler
 }
 
 /**
  * This searches for diagonal patterns and returns the corresponding weights.
  */
-vec2 SMAACalculateDiagWeights(sampler2DMS edgesTex, sampler2DMS areaTex, vec2 texcoord, vec2 e, vec4 subsampleIndices) {
+vec2 SMAACalculateDiagWeights(sampler2D edgesTex, sampler2D areaTex, vec2 texcoord, vec2 e, vec4 subsampleIndices) {
   vec2 weights = vec2(0.0, 0.0);
 
   // Search for the line ends:
@@ -275,7 +263,7 @@ vec2 SMAACalculateDiagWeights(sampler2DMS edgesTex, sampler2DMS areaTex, vec2 te
  * @PSEUDO_GATHER4), and adds 0, 1 or 2, depending on which edges and
  * crossing edges are active.
  */
-float SMAASearchLength(sampler2DMS searchTex, vec2 e, float offset) {
+float SMAASearchLength(sampler2D searchTex, vec2 e, float offset) {
   // The texture is flipped vertically, with left and right cases taking half
   // of the space horizontally:
   vec2 scale = SMAA_SEARCHTEX_SIZE * vec2(0.5, -1.0);
@@ -291,13 +279,13 @@ float SMAASearchLength(sampler2DMS searchTex, vec2 e, float offset) {
   bias *= 1.0 / SMAA_SEARCHTEX_PACKED_SIZE;
 
   // Lookup the search texture:
-  return SMAA_SEARCHTEX_SELECT(textureColor(searchTex, mad(scale, e, bias))); // LinearSampler
+  return SMAA_SEARCHTEX_SELECT(texture(searchTex, mad(scale, e, bias))); // LinearSampler
 }
 
 /**
  * Horizontal/vertical search functions for the 2nd pass.
  */
-float SMAASearchXLeft(sampler2DMS edgesTex, sampler2DMS searchTex, vec2 texcoord, float end) {
+float SMAASearchXLeft(sampler2D edgesTex, sampler2D searchTex, vec2 texcoord, float end) {
   /**
     * @PSEUDO_GATHER4
     * This texcoord has been offset by (-0.25, -0.125) in the vertex shader to
@@ -308,7 +296,7 @@ float SMAASearchXLeft(sampler2DMS edgesTex, sampler2DMS searchTex, vec2 texcoord
   vec2 e = vec2(0.0, 1.0);
   for (int i = 0; i < SMAA_MAX_SEARCH_STEPS; i++) {
     if (!(texcoord.x > end && e.g > 0.8281 && e.r == 0.0)) break;
-    e = textureColor(edgesTex, texcoord).rg; // LinearSampler
+    e = texture(edgesTex, texcoord).rg; // LinearSampler
     texcoord = mad(-vec2(2.0, 0.0), SMAA_RT_METRICS.xy, texcoord);
   }
 
@@ -328,30 +316,30 @@ float SMAASearchXLeft(sampler2DMS edgesTex, sampler2DMS searchTex, vec2 texcoord
   // return mad(SMAA_RT_METRICS.x, offset, texcoord.x);
 }
 
-float SMAASearchXRight(sampler2DMS edgesTex, sampler2DMS searchTex, vec2 texcoord, float end) {
+float SMAASearchXRight(sampler2D edgesTex, sampler2D searchTex, vec2 texcoord, float end) {
   vec2 e = vec2(0.0, 1.0);
   for (int i = 0; i < SMAA_MAX_SEARCH_STEPS; i++) { if (!(texcoord.x < end && e.g > 0.8281 && e.r == 0.0)) break;
-    e = textureColor(edgesTex, texcoord).rg; // LinearSampler
+    e = texture(edgesTex, texcoord).rg; // LinearSampler
     texcoord = mad(vec2(2.0, 0.0), SMAA_RT_METRICS.xy, texcoord);
   }
   float offset = mad(-(255.0 / 127.0), SMAASearchLength(searchTex, e, 0.5), 3.25);
   return mad(-SMAA_RT_METRICS.x, offset, texcoord.x);
 }
 
-float SMAASearchYUp(sampler2DMS edgesTex, sampler2DMS searchTex, vec2 texcoord, float end) {
+float SMAASearchYUp(sampler2D edgesTex, sampler2D searchTex, vec2 texcoord, float end) {
   vec2 e = vec2(1.0, 0.0);
   for (int i = 0; i < SMAA_MAX_SEARCH_STEPS; i++) { if (!(texcoord.y > end && e.r > 0.8281 && e.g == 0.0)) break;
-    e = textureColor(edgesTex, texcoord).rg; // LinearSampler
+    e = texture(edgesTex, texcoord).rg; // LinearSampler
     texcoord = mad(-vec2(0.0, 2.0), SMAA_RT_METRICS.xy, texcoord);
   }
   float offset = mad(-(255.0 / 127.0), SMAASearchLength(searchTex, e.gr, 0.0), 3.25);
   return mad(SMAA_RT_METRICS.y, offset, texcoord.y);
 }
 
-float SMAASearchYDown(sampler2DMS edgesTex, sampler2DMS searchTex, vec2 texcoord, float end) {
+float SMAASearchYDown(sampler2D edgesTex, sampler2D searchTex, vec2 texcoord, float end) {
   vec2 e = vec2(1.0, 0.0);
   for (int i = 0; i < SMAA_MAX_SEARCH_STEPS; i++) { if (!(texcoord.y < end && e.r > 0.8281 && e.g == 0.0)) break;
-    e = textureColor(edgesTex, texcoord).rg; // LinearSampler
+    e = texture(edgesTex, texcoord).rg; // LinearSampler
     texcoord = mad(vec2(0.0, 2.0), SMAA_RT_METRICS.xy, texcoord);
   }
   float offset = mad(-(255.0 / 127.0), SMAASearchLength(searchTex, e.gr, 0.5), 3.25);
@@ -362,7 +350,7 @@ float SMAASearchYDown(sampler2DMS edgesTex, sampler2DMS searchTex, vec2 texcoord
  * Ok, we have the distance and both crossing edges. So, what are the areas
  * at each side of current edge?
  */
-vec2 SMAAArea(sampler2DMS areaTex, vec2 dist, float e1, float e2, float offset) {
+vec2 SMAAArea(sampler2D areaTex, vec2 dist, float e1, float e2, float offset) {
   // Rounding prevents precision errors of bilinear filtering:
   vec2 texcoord = mad(vec2(SMAA_AREATEX_MAX_DISTANCE, SMAA_AREATEX_MAX_DISTANCE), round(4.0 * vec2(e1, e2)), dist);
 
@@ -373,11 +361,11 @@ vec2 SMAAArea(sampler2DMS areaTex, vec2 dist, float e1, float e2, float offset) 
   texcoord.y = mad(SMAA_AREATEX_SUBTEX_SIZE, offset, texcoord.y);
 
   // Do it!
-  return SMAA_AREATEX_SELECT(textureColor(areaTex, texcoord)); // LinearSampler
+  return SMAA_AREATEX_SELECT(texture(areaTex, texcoord)); // LinearSampler
 }
 
 // Corner Detection Functions
-void SMAADetectHorizontalCornerPattern(sampler2DMS edgesTex, inout vec2 weights, vec4 texcoord, vec2 d) {
+void SMAADetectHorizontalCornerPattern(sampler2D edgesTex, inout vec2 weights, vec4 texcoord, vec2 d) {
   #if !defined(SMAA_DISABLE_CORNER_DETECTION)
   vec2 leftRight = step(d.xy, d.yx);
   vec2 rounding = (1.0 - SMAA_CORNER_ROUNDING_NORM) * leftRight;
@@ -394,7 +382,7 @@ void SMAADetectHorizontalCornerPattern(sampler2DMS edgesTex, inout vec2 weights,
   #endif
 }
 
-void SMAADetectVerticalCornerPattern(sampler2DMS edgesTex, inout vec2 weights, vec4 texcoord, vec2 d) {
+void SMAADetectVerticalCornerPattern(sampler2D edgesTex, inout vec2 weights, vec4 texcoord, vec2 d) {
   #if !defined(SMAA_DISABLE_CORNER_DETECTION)
   vec2 leftRight = step(d.xy, d.yx);
   vec2 rounding = (1.0 - SMAA_CORNER_ROUNDING_NORM) * leftRight;
@@ -416,7 +404,7 @@ void main() {
   vec4 subsampleIndices = vec4(0.0); // Just pass zero for SMAA 1x, see @SUBSAMPLE_INDICES.
   // subsampleIndices = vec4(1.0, 1.0, 1.0, 0.0);
   vec4 weights = vec4(0.0, 0.0, 0.0, 0.0);
-  vec2 e = textureColor(edgesTex, v_texcoord).rg;
+  vec2 e = texture(edgesTex, v_texcoord).rg;
 
   if (e.g > 0.0) { // Edge at north
 
@@ -441,7 +429,7 @@ void main() {
     // Now fetch the left crossing edges, two at a time using bilinear
     // filtering. Sampling at -0.25 (see @CROSSING_OFFSET) enables to
     // discern what value each edge has:
-    float e1 = textureColor(edgesTex, coords.xy).r; // LinearSampler
+    float e1 = texture(edgesTex, coords.xy).r; // LinearSampler
 
     // Find the distance to the right:
     coords.z = SMAASearchXRight(edgesTex, searchTex, vOffset[0].zw, vOffset[2].y);
@@ -482,7 +470,7 @@ void main() {
     d.x = coords.y;
 
     // Fetch the top crossing edges:
-    float e1 = textureColor(edgesTex, coords.xy).g; // LinearSampler
+    float e1 = texture(edgesTex, coords.xy).g; // LinearSampler
 
     // Find the distance to the bottom:
     coords.z = SMAASearchYDown(edgesTex, searchTex, vOffset[1].zw, vOffset[2].w);

--- a/src/RiveQtQuickItem/shaders/qt6/smaa-weights.vert
+++ b/src/RiveQtQuickItem/shaders/qt6/smaa-weights.vert
@@ -50,7 +50,6 @@ layout(location = 2) out vec4 vOffset[3];
 layout(std140, binding = 0) uniform buf {
     vec2 resolution;
     int flip;
-    int sampleCount;
 } ubuf;
 
 void main() {
@@ -61,7 +60,7 @@ void main() {
     v_texcoord.y = 1.0 - v_texcoord.y;
 
   vPixCoord = v_texcoord * SMAA_RT_METRICS.zw;
-
+  
   // We will use these offsets for the searches later on (see @PSEUDO_GATHER4):
   vOffset[0] = mad(SMAA_RT_METRICS.xyxy, vec4(-0.25, -0.125,  1.25, -0.125), v_texcoord.xyxy);
   vOffset[1] = mad(SMAA_RT_METRICS.xyxy, vec4(-0.125, -0.25, -0.125,  1.25), v_texcoord.xyxy);


### PR DESCRIPTION
Enable MSAA via render buffers
   
This is the canonical Qt Quick way of enabling MSAA and fixes "Framebuffer incomplete"
errors when using the OpenGL RHI backend
   
Now the user can enable MSAA by using QSurfaceFormat:
   
```
QSurfaceFormat f;
f.setSamples(4);
QSurfaceFormat::setDefaultFormat(f);
```
    
MSAA is switched off by setting the sample number to 1. If the platform
doesn't support MSAA, the internal SMAA postprocessing code path can still
be used (but this code path comes with a slightly performance penalty);

`postprocessingMode: RiveQtQuickItem.SMAA // in QML
`