### PR TITLE
cmake: Add feature summary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,8 @@ if(${RQQRP_RIVE_TEXT_RENDERING})
     add_compile_definitions(WITH_RIVE_TEXT)
 endif()
 
+include(FeatureSummary)
+
 # Find Qt package
 find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core Gui Qml Quick OpenGL )
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Qml Gui Quick OpenGL)
@@ -63,3 +65,4 @@ if(RQQRP_BUILD_EXAMPLES)
     add_subdirectory(examples)
 endif()
 
+feature_summary(WHAT ALL FATAL_ON_MISSING_REQUIRED_PACKAGES)


### PR DESCRIPTION
Prints the found and required packages at configure time. Makes it easier to spot e.g. with which Qt version it is going to be built.

Not entirely sure why it shows the detailed dependencies as OPTIONAL…

```
-- The following OPTIONAL packages have been found:

 * Qt6CoreTools (required version >= 6.8.0)
 * Qt6Core
 * Qt6QmlTools (required version >= 6.8.0)
 * Qt6Qml
 * OpenGL
 * XKB (required version >= 0.5.0), XKB API common to servers and clients., <http://xkbcommon.org>
 * Qt6GuiTools (required version >= 6.8.0)
 * Qt6DBusTools (required version >= 6.8.0)
 * Qt6Gui
 * Qt6QuickTools (required version >= 6.8.0)
 * WrapVulkanHeaders
 * Qt6Quick
 * Python3
 * Threads
 * Qt6ShaderToolsTools (required version >= 6.8.0)
 * Qt6ShaderTools

-- The following REQUIRED packages have been found:

 * QT
 * Qt6
```